### PR TITLE
Make async stuff work reliably

### DIFF
--- a/src/agent/Buffer.ts
+++ b/src/agent/Buffer.ts
@@ -20,6 +20,7 @@
 import { createLogger } from '../logging';
 import Segment from '../trace/context/Segment';
 import config from '../config/AgentConfig';
+import TraceReportClient from '../agent/protocol/grpc/clients/TraceReportClient';
 
 const logger = createLogger(__filename);
 
@@ -42,6 +43,7 @@ class Buffer {
       return this;
     }
     this.buffer.push(segment);
+    TraceReportClient.ref();  // this is currently hard-coded for grpc, if other protocols added need to change
 
     return this;
   }

--- a/src/agent/protocol/grpc/clients/TraceReportClient.ts
+++ b/src/agent/protocol/grpc/clients/TraceReportClient.ts
@@ -31,6 +31,7 @@ const logger = createLogger(__filename);
 
 class TraceReportClient implements Client {
   reporterClient: TraceSegmentReportServiceClient;
+  timeout: any;
 
   constructor() {
     this.reporterClient = new TraceSegmentReportServiceClient(
@@ -42,6 +43,10 @@ class TraceReportClient implements Client {
 
   get isConnected(): boolean {
     return this.reporterClient.getChannel().getConnectivityState(true) === connectivityState.READY;
+  }
+
+  ref() {
+    this.timeout.ref();
   }
 
   start() {
@@ -72,11 +77,11 @@ class TraceReportClient implements Client {
 
         stream.end();
       } finally {
-        setTimeout(reportFunction, 1000).unref();
+        this.timeout = setTimeout(reportFunction, 1000).unref();
       }
     };
 
-    setTimeout(reportFunction, 1000).unref();
+    this.timeout = setTimeout(reportFunction, 1000).unref();
   }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -52,3 +52,4 @@ class Agent {
 }
 
 export default new Agent();
+export { default as ContextManager } from './trace/context/ContextManager';

--- a/src/plugins/HttpPlugin.ts
+++ b/src/plugins/HttpPlugin.ts
@@ -94,8 +94,7 @@ class HttpPlugin implements SwPlugin {
           if (res.statusMessage) {
             span.tag(Tag.httpStatusMsg(res.statusMessage));
           }
-          span.stop();
-          stopped++;
+          stopIfNotStopped();
         });
 
         return request;

--- a/src/plugins/HttpPlugin.ts
+++ b/src/plugins/HttpPlugin.ts
@@ -23,6 +23,7 @@ import { ClientRequest, IncomingMessage, RequestOptions, ServerResponse } from '
 import ContextManager from '../trace/context/ContextManager';
 import { Component } from '../trace/Component';
 import Tag from '../Tag';
+import Span from '../trace/span/Span';
 import { SpanLayer } from '../proto/language-agent/Tracing_pb';
 import { ContextCarrier } from '../trace/context/ContextCarrier';
 import { createLogger } from '../logging';
@@ -59,26 +60,43 @@ class HttpPlugin implements SwPlugin {
               };
         const operation = pathname.replace(/\?.*$/g, '');
 
-        const span = ContextManager.current.newExitSpan(operation, host).start();
-        span.component = Component.HTTP;
-        span.layer = SpanLayer.HTTP;
-        span.tag(Tag.httpURL(host + pathname));
+        const [span, request]: [Span, ClientRequest] = ContextManager.withSpanNoStop(
+            ContextManager.current.newExitSpan(operation, host), (_span: Span, args) => {
 
-        const request: ClientRequest = original.apply(this, arguments);
+          _span.component = Component.HTTP;
+          _span.layer = SpanLayer.HTTP;
+          _span.tag(Tag.httpURL(host + pathname));
 
-        span.extract().items.forEach((item) => {
-          request.setHeader(item.key, item.value);
-        });
+          const _request = original.apply(this, args);
+
+          _span.extract().items.forEach((item) => {
+            _request.setHeader(item.key, item.value);
+          });
+
+          return [_span, _request];
+
+        }, arguments);
 
         span.async();
 
+        let stopped = 0;  // compensating if request aborted right after creation 'close' is not emitted
+        const stopIfNotStopped = () => !stopped++ ? span.stop() : null;
+        request.on('abort', stopIfNotStopped);  // make sure we stop only once
+        request.on('close', stopIfNotStopped);
+        request.on('error', stopIfNotStopped);
+
         request.prependListener('response', (res) => {
+          span.resync();
           span.tag(Tag.httpStatusCode(res.statusCode));
           if (res.statusCode && res.statusCode >= 400) {
             span.errored = true;
           }
+          if (res.statusMessage) {
+            span.tag(Tag.httpStatusMsg(res.statusMessage));
+          }
+          span.stop();
+          stopped++;
         });
-        request.on('close', () => span.await().stop());
 
         return request;
       };
@@ -94,26 +112,26 @@ class HttpPlugin implements SwPlugin {
           return original.apply(this, arguments);
         }
 
-        const args = arguments;
-        const self = this;
+        const [req, res] = [arguments[1] as IncomingMessage, arguments[2] as ServerResponse];
 
-        return ContextManager.withContext(() => {
-          const [req, res] = [args[1] as IncomingMessage, args[2] as ServerResponse];
+        const headers = req.rawHeaders || [];
+        const headersMap: { [key: string]: string } = {};
 
-          const headers = req.rawHeaders || [];
-          const headersMap: { [key: string]: string } = {};
+        for (let i = 0; i < headers.length / 2; i += 2) {
+          headersMap[headers[i]] = headers[i + 1];
+        }
 
-          for (let i = 0; i < headers.length / 2; i += 2) {
-            headersMap[headers[i]] = headers[i + 1];
-          }
+        const carrier = ContextCarrier.from(headersMap);
+        const operation = (req.url || '/').replace(/\?.*/g, '');
 
-          const carrier = ContextCarrier.from(headersMap);
+        return ContextManager.withSpan(ContextManager.current.newEntrySpan(operation, carrier),
+            (span, self, args) => {
 
-          const operation = (req.url || '/').replace(/\?.*/g, '');
-          const span = ContextManager.current.newEntrySpan(operation, carrier).start();
           span.component = Component.HTTP_SERVER;
           span.layer = SpanLayer.HTTP;
-          span.tag(Tag.httpURL(req.url));
+          span.tag(Tag.httpURL((req.headers.host || '') + req.url));
+
+          const ret = original.apply(self, args);
 
           span.tag(Tag.httpStatusCode(res.statusCode));
           if (res.statusCode && res.statusCode >= 400) {
@@ -123,12 +141,9 @@ class HttpPlugin implements SwPlugin {
             span.tag(Tag.httpStatusMsg(res.statusMessage));
           }
 
-          res.on('close', () => {
-            span.stop();
-          });
+          return ret;
 
-          return original.apply(self, args);
-        });
+        }, this, arguments);
       };
     })(http.Server.prototype.emit);
   }

--- a/src/trace/context/Context.ts
+++ b/src/trace/context/Context.ts
@@ -24,7 +24,6 @@ import { ContextCarrier } from './ContextCarrier';
 
 export default interface Context {
   segment: Segment;
-  spans: Span[];
 
   newLocalSpan(operation: string): Span;
 
@@ -36,13 +35,13 @@ export default interface Context {
 
   stop(span: Span): boolean;
 
+  async(span: Span): void;
+
+  resync(span: Span): void;
+
   currentSpan(): Span | undefined;
 
   capture(): Snapshot;
 
   restore(snapshot: Snapshot): void;
-
-  async(span: Span): void;
-
-  await(span: Span): void;
 }

--- a/src/trace/context/Context.ts
+++ b/src/trace/context/Context.ts
@@ -35,8 +35,13 @@ export default interface Context {
 
   stop(span: Span): boolean;
 
+  /* This should be called just before a span is passed to a different async context, like for example a callback from
+     an asynchronous operation the code belonging to the span initiated. After this is called a span should only call
+     .resync() or .stop(). See HttpPlugin.interceptClientRequest() in plugins/HttpPlugin.ts for example of usage. */
   async(span: Span): void;
 
+  /* This should be called upon entering the new async context for a span that has previously executed .async(), it
+     should be the first thing the callback function belonging to the span does. */
   resync(span: Span): void;
 
   currentSpan(): Span | undefined;

--- a/src/trace/context/DummyContext.ts
+++ b/src/trace/context/DummyContext.ts
@@ -32,26 +32,23 @@ export default class DummyContext implements Context {
     operation: '',
     type: SpanType.LOCAL,
   });
-  spans: Span[] = [];
   segment: Segment = new Segment();
   depth = 0;
 
   newEntrySpan(operation: string, carrier?: ContextCarrier): Span {
-    this.depth++;
     return this.span;
   }
 
   newExitSpan(operation: string, peer: string, carrier?: ContextCarrier): Span {
-    this.depth++;
     return this.span;
   }
 
   newLocalSpan(operation: string): Span {
-    this.depth++;
     return this.span;
   }
 
   start(): Context {
+    this.depth++;
     return this;
   }
 
@@ -59,8 +56,16 @@ export default class DummyContext implements Context {
     return --this.depth === 0;
   }
 
+  async(span: Span) {
+    return;
+  }
+
+  resync(span: Span) {
+    return;
+  }
+
   currentSpan(): Span {
-    return this.spans[this.spans.length - 1];
+    throw new Error('DummyContext.currentSpan() should never be called!');
   }
 
   capture(): Snapshot {
@@ -73,14 +78,6 @@ export default class DummyContext implements Context {
   }
 
   restore(snapshot: Snapshot) {
-    return;
-  }
-
-  async(span: Span) {
-    return;
-  }
-
-  await(span: Span) {
     return;
   }
 }

--- a/src/trace/span/EntrySpan.ts
+++ b/src/trace/span/EntrySpan.ts
@@ -25,8 +25,6 @@ import { SpanLayer, SpanType } from '../../proto/language-agent/Tracing_pb';
 import { ContextCarrier } from '../context/ContextCarrier';
 
 export default class EntrySpan extends StackedSpan {
-  maxDepth = 0;
-
   constructor(options: SpanCtorOptions) {
     super(
       Object.assign(options, {
@@ -36,10 +34,7 @@ export default class EntrySpan extends StackedSpan {
   }
 
   start(): this {
-    this.maxDepth = ++this.depth;
-    if (this.maxDepth === 1) {
-      super.start();
-    }
+    super.start();
     this.layer = SpanLayer.UNKNOWN;
     this.component = Component.UNKNOWN;
     this.logs.splice(0, this.logs.length);

--- a/src/trace/span/ExitSpan.ts
+++ b/src/trace/span/ExitSpan.ts
@@ -22,6 +22,7 @@ import { SpanCtorOptions } from './Span';
 import config from '../../config/AgentConfig';
 import { SpanType } from '../../proto/language-agent/Tracing_pb';
 import { ContextCarrier } from '../context/ContextCarrier';
+import ContextManager from '../context/ContextManager';
 
 export default class ExitSpan extends StackedSpan {
   constructor(options: SpanCtorOptions) {
@@ -32,11 +33,6 @@ export default class ExitSpan extends StackedSpan {
     );
   }
 
-  start(): this {
-    this.depth++;
-    return super.start();
-  }
-
   extract(): ContextCarrier {
     return new ContextCarrier(
       this.context.segment.relatedTraces[0],
@@ -44,7 +40,7 @@ export default class ExitSpan extends StackedSpan {
       this.id,
       config.serviceName,
       config.serviceInstance,
-      this.context.spans[0].operation,
+      ContextManager.spans[0].operation,
       this.peer,
       [],
     );

--- a/src/trace/span/Span.ts
+++ b/src/trace/span/Span.ts
@@ -59,8 +59,6 @@ export default abstract class Span {
   endTime = 0;
   errored = false;
 
-  _async = false;
-
   constructor(options: SpanCtorOptions & { type: SpanType }) {
     this.context = options.context;
     this.operation = options.operation;
@@ -86,6 +84,18 @@ export default abstract class Span {
       console.info('kkkkkkkkkkkkkkkkkkkkkkkkkl')
     }
     this.context.stop(this);
+    return this;
+  }
+
+  async(): this {
+    logger.debug(`Async span ${this.operation}`, this);
+    this.context.async(this);
+    return this;
+  }
+
+  resync(): this {
+    logger.debug(`Resync span ${this.operation}`, this);
+    this.context.resync(this);
     return this;
   }
 
@@ -145,21 +155,5 @@ export default abstract class Span {
       this.refs.push(ref);
     }
     return this;
-  }
-
-  async(): this {
-    this._async = true;
-    this.context.async(this);
-    return this;
-  }
-
-  await(): this {
-    this.context.await(this);
-    this._async = false;
-    return this;
-  }
-
-  get isAsync(): boolean {
-    return this._async;
   }
 }

--- a/src/trace/span/StackedSpan.ts
+++ b/src/trace/span/StackedSpan.ts
@@ -31,6 +31,13 @@ export default class StackedSpan extends Span {
     super(options);
   }
 
+  start(): this {
+    if (++this.depth === 1) {
+      super.start();
+    }
+    return this;
+  }
+
   finish(segment: Segment): boolean {
     return --this.depth === 0 && super.finish(segment);
   }

--- a/tests/plugins/http/expected.data.yaml
+++ b/tests/plugins/http/expected.data.yaml
@@ -36,7 +36,8 @@ segmentItems:
             tags:
               - { key: http.url, value: /test }
               - { key: http.status.code, value: '200' }
-            refs:
+              - { key: http.status.msg, value: OK }
+             refs:
               - { parentEndpoint: '', networkAddress: 'server:5000', refType: CrossProcess,
                   parentSpanId: 1, parentTraceSegmentId: not null, parentServiceInstance: not null,
                   parentService: client, traceId: not null }
@@ -55,6 +56,7 @@ segmentItems:
             tags:
               - { key: http.url, value: httpbin.org/json }
               - { key: http.status.code, value: '200' }
+              - { key: http.status.msg, value: OK }
   - serviceName: client
     segmentSize: 1
     segments:
@@ -75,6 +77,7 @@ segmentItems:
             tags:
               - { key: http.url, value: /test }
               - { key: http.status.code, value: '200' }
+              - { key: http.status.msg, value: OK }
           - operationName: /test
             operationId: 0
             parentSpanId: 0
@@ -90,3 +93,4 @@ segmentItems:
             tags:
               - { key: http.url, value: 'server:5000/test' }
               - { key: http.status.code, value: '200' }
+              - { key: http.status.msg, value: OK }

--- a/tests/plugins/http/expected.data.yaml
+++ b/tests/plugins/http/expected.data.yaml
@@ -34,10 +34,9 @@ segmentItems:
             peer: ''
             skipAnalysis: false
             tags:
-              - { key: http.url, value: /test }
+              - { key: http.url, value: server:5000/test }
               - { key: http.status.code, value: '200' }
-              - { key: http.status.msg, value: OK }
-             refs:
+            refs:
               - { parentEndpoint: '', networkAddress: 'server:5000', refType: CrossProcess,
                   parentSpanId: 1, parentTraceSegmentId: not null, parentServiceInstance: not null,
                   parentService: client, traceId: not null }
@@ -75,9 +74,8 @@ segmentItems:
             peer: ''
             skipAnalysis: false
             tags:
-              - { key: http.url, value: /test }
+              - { key: http.url, value: localhost:5001/test }
               - { key: http.status.code, value: '200' }
-              - { key: http.status.msg, value: OK }
           - operationName: /test
             operationId: 0
             parentSpanId: 0


### PR DESCRIPTION
This is not done yet but I am opening the PR before the changes get too big so you can see the direction I am going and comment. I am implementing basically the same mechanism as in the Python agent to allow async stuff to work without losing spans or weird parent-child relationships where they should be siblings. Here are a few notes / questions so far:

* Context.capture() and restore() will be made redundant / unnecessary by this?

* ContextManagere.withSpan() export to user?

* Node 10 does not have AsyncLocalStorage, will need to provide custom substitute class for this (using async_hooks.createHook init and destroy to track parent-child relationships).

* I had this question with the Python agent whether entry spans should always start with a new context but decided against it because maybe someone wants a previous local context for some debug or other reason to chain before the entry context? So I did the same here and disabled fresh context on Entry span but rather just let it use the normal inheritance chain, which should eventually give a new context unless the user specifically prevents it.

* Has problem as Python agent with background updater not firing if application exits very quickly, should not exit until all data sent, probably should hook 'beforeExit' event and flush segments, should do same in Python.
