### PR TITLE
withSpanAwait(), HttpPlugin errorer on abort/error

### DIFF
--- a/src/plugins/HttpPlugin.ts
+++ b/src/plugins/HttpPlugin.ts
@@ -80,10 +80,10 @@ class HttpPlugin implements SwPlugin {
         span.async();
 
         let stopped = 0;  // compensating if request aborted right after creation 'close' is not emitted
-        const stopIfNotStopped = () => !stopped++ ? span.stop() : null;
-        request.on('abort', stopIfNotStopped);  // make sure we stop only once
+        const stopIfNotStopped = () => !stopped++ ? span.stop() : null;  // make sure we stop only once
         request.on('close', stopIfNotStopped);
-        request.on('error', stopIfNotStopped);
+        request.on('abort', () => (span.errored = true, stopIfNotStopped()));
+        request.on('error', (err) => (span.error(err), stopIfNotStopped()));
 
         request.prependListener('response', (res) => {
           span.resync();

--- a/src/trace/context/ContextManager.ts
+++ b/src/trace/context/ContextManager.ts
@@ -77,6 +77,20 @@ class ContextManager {
     }
   }
 
+  async withSpanAwait(span: Span, callback: (...args: any[]) => any, ...args: any[]): Promise<any> {
+    if(!span.startTime)
+      span.start();
+
+    try {
+      return await callback(span, ...args);
+    } catch (e) {
+      span.error(e);
+      throw e;
+    } finally {
+      span.stop();
+    }
+  }
+
   withSpanNoStop(span: Span, callback: (...args: any[]) => any, ...args: any[]): any {
     if(!span.startTime)
       span.start();


### PR DESCRIPTION
Two small changes:
* Added ContextManager.withSpanAwait() to allow for example user local spans to synchronize with asynchronous exit spans (make sure the local span stops AFTER the exit span finishes).
* Made HttpPlugin request events 'abort' and 'error' mark the span as errored.