### PR TITLE
[Enhancement] tweaks for better error handling

### DIFF
--- a/src/trace/context/ContextManager.ts
+++ b/src/trace/context/ContextManager.ts
@@ -68,7 +68,7 @@ class ContextManager {
       span.start();
 
     try {
-      return callback(span, ...args);
+      return callback(...args);
     } catch (e) {
       span.error(e);
       throw e;
@@ -82,25 +82,12 @@ class ContextManager {
       span.start();
 
     try {
-      return await callback(span, ...args);
+      return await callback(...args);
     } catch (e) {
       span.error(e);
       throw e;
     } finally {
       span.stop();
-    }
-  }
-
-  withSpanNoStop(span: Span, callback: (...args: any[]) => any, ...args: any[]): any {
-    if(!span.startTime)
-      span.start();
-
-    try {
-      return callback(span, ...args);
-    } catch (e) {
-      span.error(e);
-      span.stop();
-      throw e;
     }
   }
 }


### PR DESCRIPTION
* Removed ContextManager.withSpanNoStop() to clean up interface since this was only meant to be used in plugins and so the plugins themselves should do this.
* Changed ContextManager.withSpan() and .withSpanAsync() to not insert span as first argument but rather just pass the args through to allow more generalized use, for example `ContextManager.withSpanAsync(user_defined_span, unsupported_async_URL_requester, requester_arg1, ...)`.
* Reworked HttpPlugin:http.request() to better cover and handle error conditions, should be 100% covered now (before there was a range between `span.async()` and the callback where an unexpected error could cause the span to not be stopped).
