### PR TITLE
tslib as normal not dev dependancy

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
     "ts-jest": "^26.4.4",
     "ts-node": "^8.10.2",
     "tsconfig-paths": "^3.9.0",
-    "tslib": "^2.0.3",
     "tslint": "^6.1.2",
     "tslint-config-prettier": "^1.18.0",
     "typescript": "^3.9.5",
@@ -61,6 +60,7 @@
     "google-protobuf": "^3.12.2",
     "grpc": "^1.10.1",
     "semver": "^7.3.2",
+    "tslib": "^2.0.3",
     "uuid": "^8.1.0",
     "winston": "^3.2.1"
   }


### PR DESCRIPTION
This dependency missing if installed normally as npm package, so moved from dev to normal dependancies. If this is not the right way to do it then feel free to correct it some other way.