### PR TITLE
[WIP] express plugin, make spans actually work

### DIFF
--- a/src/agent/Buffer.ts
+++ b/src/agent/Buffer.ts
@@ -49,6 +49,4 @@ class Buffer {
   }
 }
 
-export default new Buffer(
-  Number.isSafeInteger(config.maxBufferSize) ? Number.parseInt(config.maxBufferSize, 10) : 1000,
-);
+export default new Buffer(config.maxBufferSize);

--- a/src/core/PluginInstaller.ts
+++ b/src/core/PluginInstaller.ts
@@ -28,17 +28,16 @@ const logger = createLogger(__filename);
 let topModule = module;
 for (; topModule.parent; topModule = topModule.parent);
 
-const topResolve = (request: string) => (module.constructor as any)._resolveFilename(request, topModule)
-
 class PluginInstaller {
   pluginDir: string;
   require: (name: string) => any = topModule.require.bind(topModule);
+  resolve = (request: string) => (module.constructor as any)._resolveFilename(request, topModule);
 
   constructor() {
     this.pluginDir = path.resolve(__dirname, '..', 'plugins');
   }
 
-  private isBuiltIn = (module: string): boolean => topResolve(module) === module;
+  private isBuiltIn = (module: string): boolean => this.resolve(module) === module;
 
   private checkModuleVersion = (plugin: SwPlugin): { version: string; isSupported: boolean } => {
     try {
@@ -55,7 +54,7 @@ class PluginInstaller {
       };
     }
 
-    const packageJsonPath = topResolve(`${plugin.module}/package.json`);
+    const packageJsonPath = this.resolve(`${plugin.module}/package.json`);
     const version = this.require(packageJsonPath).version;
 
     if (!semver.satisfies(version, plugin.versions)) {

--- a/src/core/PluginInstaller.ts
+++ b/src/core/PluginInstaller.ts
@@ -75,20 +75,28 @@ class PluginInstaller {
     fs.readdirSync(this.pluginDir)
       .filter((file) => !(file.endsWith('.d.ts') || file.endsWith('.js.map')))
       .forEach((file) => {
-        const plugin = require(path.join(this.pluginDir, file)).default as SwPlugin;
-        const { isSupported, version } = this.checkModuleVersion(plugin);
-
-        if (!isSupported) {
-          logger.info(`Plugin ${plugin.module} ${version} doesn't satisfy the supported version ${plugin.versions}`);
-          return;
-        }
-
-        logger.info(`Installing plugin ${plugin.module} ${plugin.versions}`);
+        let plugin;
+        const pluginFile = path.join(this.pluginDir, file);
 
         try {
+          plugin = require(pluginFile).default as SwPlugin;
+          const { isSupported, version } = this.checkModuleVersion(plugin);
+
+          if (!isSupported) {
+            logger.info(`Plugin ${plugin.module} ${version} doesn't satisfy the supported version ${plugin.versions}`);
+            return;
+          }
+
+          logger.info(`Installing plugin ${plugin.module} ${plugin.versions}`);
+
           plugin.install();
+
         } catch (e) {
-          logger.error(`Error installing plugin ${plugin.module} ${plugin.versions}`);
+          if (plugin) {
+            logger.error(`Error installing plugin ${plugin.module} ${plugin.versions}`);
+          } else {
+            logger.error(`Error processing plugin ${pluginFile}`);
+          }
         }
       });
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,7 +17,7 @@
  *
  */
 
-import config, { AgentConfig } from './config/AgentConfig';
+import config, { AgentConfig, finalizeConfig } from './config/AgentConfig';
 import GrpcProtocol from './agent/protocol/grpc/GrpcProtocol';
 import { createLogger } from './logging';
 import Protocol from './agent/protocol/Protocol';
@@ -36,6 +36,7 @@ class Agent {
     }
 
     Object.assign(config, options);
+    finalizeConfig(config);
 
     if (this.started) {
       throw new Error('SkyWalking agent is already started and can only be started once.');

--- a/src/plugins/AxiosPlugin.ts
+++ b/src/plugins/AxiosPlugin.ts
@@ -1,0 +1,121 @@
+/*!
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import SwPlugin from '../core/SwPlugin';
+import { URL } from 'url';
+import ContextManager from '../trace/context/ContextManager';
+import { Component } from '../trace/Component';
+import Span from '../trace/span/Span';
+import Tag from '../Tag';
+import { SpanLayer } from '../proto/language-agent/Tracing_pb';
+import { createLogger } from '../logging';
+import PluginInstaller from '../core/PluginInstaller';
+
+const logger = createLogger(__filename);
+
+class AxiosPlugin implements SwPlugin {
+  readonly module = 'axios';
+  readonly versions = '*';
+  axios = PluginInstaller.require('axios').default;
+
+  install(): void {
+    if (logger.isDebugEnabled()) {
+      logger.debug('installing axios plugin');
+    }
+    this.interceptClientRequest();
+  }
+
+  private interceptClientRequest() {
+    const copyStatusAndStop = (span: Span, response: any) => {
+      if (response) {
+        if (response.status) {
+          span.tag(Tag.httpStatusCode(response.status));
+        }
+        if (response.statusText) {
+          span.tag(Tag.httpStatusMsg(response.statusText));
+        }
+      }
+
+      span.stop();
+    }
+
+    this.axios.interceptors.request.use(
+      (config: any) => {
+        config.span.resync();
+
+        (config.span as Span).inject().items.forEach((item) => {
+          config.headers.common[item.key] = item.value;
+        });
+
+        return config;
+      },
+
+      (error: any) => {
+        error.config.span.error(error);
+        error.config.span.stop();
+
+        return Promise.reject(error);
+      }
+    );
+
+    this.axios.interceptors.response.use(
+      (response: any) => {
+        copyStatusAndStop(response.config.span, response);
+
+        return response;
+      },
+
+      (error: any) => {
+        error.config.span.error(error);
+
+        copyStatusAndStop(error.config.span, error.response);
+
+        return Promise.reject(error);
+      }
+    );
+
+    const _request = this.axios.Axios.prototype.request;
+
+    this.axios.Axios.prototype.request = function (config: any) {
+      const { host, pathname: operation } = new URL(config.url);  // TODO: this may throw invalid URL
+      const span = ContextManager.current.newExitSpan(operation, host).start();
+
+      try {
+        span.component = Component.UNKNOWN;
+        span.layer = SpanLayer.HTTP;
+        span.peer = host;
+        span.tag(Tag.httpURL(host + operation));
+        span.async();
+
+        const request = _request.call(this, {...config, span});
+
+        return request;
+
+      } catch (e) {
+        span.error(e);
+        span.stop();
+
+        throw e;
+      }
+    };
+  }
+}
+
+// noinspection JSUnusedGlobalSymbols
+export default new AxiosPlugin();

--- a/src/plugins/ExpressPlugin.ts
+++ b/src/plugins/ExpressPlugin.ts
@@ -73,7 +73,7 @@ class ExpressPlugin implements SwPlugin {
 
       try {
         span.layer = SpanLayer.HTTP;
-        span.component = Component.UNKNOWN;  // Component.EXPRESS;
+        span.component = Component.EXPRESS;
         span.peer = req.headers.host || '';
         span.tag(Tag.httpURL(span.peer + req.url));
 

--- a/src/plugins/ExpressPlugin.ts
+++ b/src/plugins/ExpressPlugin.ts
@@ -1,0 +1,86 @@
+/*!
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import SwPlugin from '../core/SwPlugin';
+import { IncomingMessage, ServerResponse } from 'http';
+import ContextManager from '../trace/context/ContextManager';
+import { Component } from '../trace/Component';
+import Tag from '../Tag';
+import { SpanLayer } from '../proto/language-agent/Tracing_pb';
+import { ContextCarrier } from '../trace/context/ContextCarrier';
+import { createLogger } from '../logging';
+import PluginInstaller from '../core/PluginInstaller';
+
+const logger = createLogger(__filename);
+
+class ExpressPlugin implements SwPlugin {
+  readonly module = 'express';
+  readonly versions = '*';
+
+  install(): void {
+    if (logger.isDebugEnabled()) {
+      logger.debug('installing express plugin');
+    }
+    this.interceptServerRequest();
+  }
+
+  private interceptServerRequest() {
+    const router = PluginInstaller.require('express/lib/router');
+    const _handle = router.handle;
+
+    router.handle = function(req: IncomingMessage, res: ServerResponse, out: any) {
+      const headers = req.rawHeaders || [];
+      const headersMap: { [key: string]: string } = {};
+
+      for (let i = 0; i < headers.length / 2; i += 2) {
+        headersMap[headers[i]] = headers[i + 1];
+      }
+
+      const carrier = ContextCarrier.from(headersMap);
+      const operation = (req.url || '/').replace(/\?.*/g, '');
+      const span = ContextManager.current.newEntrySpan(operation, carrier).start();
+
+      return ContextManager.withSpan(span, () => {
+        span.layer = SpanLayer.HTTP;
+        span.component = Component.UNKNOWN;  // Component.EXPRESS;
+        span.peer =req.headers.host || '';
+        span.tag(Tag.httpURL(span.peer + req.url));
+
+        const ret = _handle.call(this, req, res, (err: Error) => {
+          out.call(this, err);
+          span.error(err);
+        });
+
+        span.tag(Tag.httpStatusCode(res.statusCode));
+        if (res.statusCode && res.statusCode >= 400) {
+          span.errored = true;
+        }
+        if (res.statusMessage) {
+          span.tag(Tag.httpStatusMsg(res.statusMessage));
+        }
+
+        return ret;
+
+      });
+    };
+  }
+}
+
+// noinspection JSUnusedGlobalSymbols
+export default new ExpressPlugin();

--- a/src/plugins/HttpPlugin.ts
+++ b/src/plugins/HttpPlugin.ts
@@ -71,7 +71,7 @@ class HttpPlugin implements SwPlugin {
 
           const request: ClientRequest = original.apply(this, arguments);
 
-          span.extract().items.forEach((item) => {
+          span.inject().items.forEach((item) => {
             request.setHeader(item.key, item.value);
           });
 

--- a/src/plugins/HttpPlugin.ts
+++ b/src/plugins/HttpPlugin.ts
@@ -60,8 +60,8 @@ class HttpPlugin implements SwPlugin {
         const operation = pathname.replace(/\?.*$/g, '');
 
         let stopped = 0;  // compensating if request aborted right after creation 'close' is not emitted
-        const span = ContextManager.current.newExitSpan(operation, host).start();
         const stopIfNotStopped = () => !stopped++ ? span.stop() : null;  // make sure we stop only once
+        const span = ContextManager.current.newExitSpan(operation, host).start();
 
         try {
           span.component = Component.HTTP;

--- a/src/plugins/HttpPlugin.ts
+++ b/src/plugins/HttpPlugin.ts
@@ -37,106 +37,55 @@ class HttpPlugin implements SwPlugin {
     if (logger.isDebugEnabled()) {
       logger.debug('installing http plugin');
     }
-    this.interceptClientRequest();
-    this.interceptServerRequest();
+
+    const http = require('http');
+    const https = require('https');
+
+    this.interceptClientRequest(http);
+    this.interceptServerRequest(http);
+    this.interceptClientRequest(https);
+    this.interceptServerRequest(https);
   }
 
-  private interceptClientRequest() {
-    const http = require('http');
+  private interceptClientRequest(module: any) {
+    const _request = module.request;
 
-    ((original) => {
-      http.request = function () {
-        const url: URL | string | RequestOptions = arguments[0];
+    module.request = function () {
+      const url: URL | string | RequestOptions = arguments[0];
 
-        const { host, pathname } =
-          url instanceof URL
-            ? url
-            : typeof url === 'string'
-            ? new URL(url)
-            : {
-                host: (url.host || url.hostname || 'unknown') + ':' + url.port,
-                pathname: url.path || '/',
-              };
-        const operation = pathname.replace(/\?.*$/g, '');
+      const { host, pathname } =
+        url instanceof URL
+          ? url
+          : typeof url === 'string'
+          ? new URL(url)
+          : {
+              host: (url.host || url.hostname || 'unknown') + ':' + url.port,
+              pathname: url.path || '/',
+            };
+      const operation = pathname.replace(/\?.*$/g, '');
 
-        let stopped = 0;  // compensating if request aborted right after creation 'close' is not emitted
-        const stopIfNotStopped = () => !stopped++ ? span.stop() : null;  // make sure we stop only once
-        const span = ContextManager.current.newExitSpan(operation, host).start();
+      let stopped = 0;  // compensating if request aborted right after creation 'close' is not emitted
+      const stopIfNotStopped = () => !stopped++ ? span.stop() : null;  // make sure we stop only once
+      const span = ContextManager.current.newExitSpan(operation, host).start();
 
-        try {
-          span.component = Component.HTTP;
-          span.layer = SpanLayer.HTTP;
-          span.peer = host;
-          span.tag(Tag.httpURL(host + pathname));
+      try {
+        span.component = Component.HTTP;
+        span.layer = SpanLayer.HTTP;
+        span.peer = host;
+        span.tag(Tag.httpURL(host + pathname));
 
-          const request: ClientRequest = original.apply(this, arguments);
+        const request: ClientRequest = _request.apply(this, arguments);
 
-          span.inject().items.forEach((item) => {
-            request.setHeader(item.key, item.value);
-          });
+        span.inject().items.forEach((item) => {
+          request.setHeader(item.key, item.value);
+        });
 
-          request.on('close', stopIfNotStopped);
-          request.on('abort', () => (span.errored = true, stopIfNotStopped()));
-          request.on('error', (err) => (span.error(err), stopIfNotStopped()));
+        request.on('close', stopIfNotStopped);
+        request.on('abort', () => (span.errored = true, stopIfNotStopped()));
+        request.on('error', (err) => (span.error(err), stopIfNotStopped()));
 
-          request.prependListener('response', (res) => {
-            span.resync();
-            span.tag(Tag.httpStatusCode(res.statusCode));
-            if (res.statusCode && res.statusCode >= 400) {
-              span.errored = true;
-            }
-            if (res.statusMessage) {
-              span.tag(Tag.httpStatusMsg(res.statusMessage));
-            }
-            stopIfNotStopped();
-          });
-
-          span.async();
-
-          return request;
-
-        } catch (e) {
-          if (!stopped) {
-            span.error(e);
-            stopIfNotStopped();
-          }
-
-          throw e;
-        }
-      };
-    })(http.request);
-  }
-
-  private interceptServerRequest() {
-    const http = require('http');
-
-    ((original) => {
-      http.Server.prototype.emit = function () {
-        if (arguments[0] !== 'request') {
-          return original.apply(this, arguments);
-        }
-
-        const [req, res] = [arguments[1] as IncomingMessage, arguments[2] as ServerResponse];
-
-        const headers = req.rawHeaders || [];
-        const headersMap: { [key: string]: string } = {};
-
-        for (let i = 0; i < headers.length / 2; i += 2) {
-          headersMap[headers[i]] = headers[i + 1];
-        }
-
-        const carrier = ContextCarrier.from(headersMap);
-        const operation = (req.url || '/').replace(/\?.*/g, '');
-        const span = ContextManager.current.newEntrySpan(operation, carrier);
-
-        return ContextManager.withSpan(span, (self, args) => {
-          span.component = Component.HTTP_SERVER;
-          span.layer = SpanLayer.HTTP;
-          span.peer = req.headers.host || '';
-          span.tag(Tag.httpURL(span.peer + req.url));
-
-          const ret = original.apply(self, args);
-
+        request.prependListener('response', (res) => {
+          span.resync();
           span.tag(Tag.httpStatusCode(res.statusCode));
           if (res.statusCode && res.statusCode >= 400) {
             span.errored = true;
@@ -144,12 +93,65 @@ class HttpPlugin implements SwPlugin {
           if (res.statusMessage) {
             span.tag(Tag.httpStatusMsg(res.statusMessage));
           }
+          stopIfNotStopped();
+        });
 
-          return ret;
+        span.async();
 
-        }, this, arguments);
-      };
-    })(http.Server.prototype.emit);
+        return request;
+
+      } catch (e) {
+        if (!stopped) {
+          span.error(e);
+          stopIfNotStopped();
+        }
+
+        throw e;
+      }
+    };
+  }
+
+  private interceptServerRequest(module: any) {
+    const _emit = module.Server.prototype.emit;
+
+    module.Server.prototype.emit = function () {
+      if (arguments[0] !== 'request') {
+        return _emit.apply(this, arguments);
+      }
+
+      const [req, res] = [arguments[1] as IncomingMessage, arguments[2] as ServerResponse];
+
+      const headers = req.rawHeaders || [];
+      const headersMap: { [key: string]: string } = {};
+
+      for (let i = 0; i < headers.length / 2; i += 2) {
+        headersMap[headers[i]] = headers[i + 1];
+      }
+
+      const carrier = ContextCarrier.from(headersMap);
+      const operation = (req.url || '/').replace(/\?.*/g, '');
+      const span = ContextManager.current.newEntrySpan(operation, carrier);
+
+      return ContextManager.withSpan(span, (self, args) => {
+        span.component = Component.HTTP_SERVER;
+        span.layer = SpanLayer.HTTP;
+        span.peer = req.headers.host || '';
+        span.tag(Tag.httpURL(span.peer + req.url));
+
+        const ret = _emit.apply(self, args);
+
+        span.tag(Tag.httpStatusCode(res.statusCode));
+        if (res.statusCode && res.statusCode >= 400) {
+          span.errored = true;
+        }
+        if (res.statusMessage) {
+          span.tag(Tag.httpStatusMsg(res.statusMessage));
+        }
+
+        return ret;
+
+      }, this, arguments);
+    };
   }
 }
 

--- a/src/plugins/HttpPlugin.ts
+++ b/src/plugins/HttpPlugin.ts
@@ -66,6 +66,7 @@ class HttpPlugin implements SwPlugin {
         try {
           span.component = Component.HTTP;
           span.layer = SpanLayer.HTTP;
+          span.peer = host;
           span.tag(Tag.httpURL(host + pathname));
 
           const request: ClientRequest = original.apply(this, arguments);
@@ -131,7 +132,8 @@ class HttpPlugin implements SwPlugin {
         return ContextManager.withSpan(span, (self, args) => {
           span.component = Component.HTTP_SERVER;
           span.layer = SpanLayer.HTTP;
-          span.tag(Tag.httpURL((req.headers.host || '') + req.url));
+          span.peer = req.headers.host || '';
+          span.tag(Tag.httpURL(span.peer + req.url));
 
           const ret = original.apply(self, args);
 

--- a/src/trace/Component.ts
+++ b/src/trace/Component.ts
@@ -22,6 +22,7 @@ export class Component {
   static HTTP = new Component(2);
   static MONGODB = new Component(9);
   static HTTP_SERVER = new Component(49);
+  // static EXPRESS = new Component(???);
 
   constructor(public id: number) {}
 }

--- a/src/trace/Component.ts
+++ b/src/trace/Component.ts
@@ -22,7 +22,7 @@ export class Component {
   static HTTP = new Component(2);
   static MONGODB = new Component(9);
   static HTTP_SERVER = new Component(49);
-  // static EXPRESS = new Component(???);
+  static EXPRESS = new Component(4002);
 
   constructor(public id: number) {}
 }

--- a/src/trace/context/SpanContext.ts
+++ b/src/trace/context/SpanContext.ts
@@ -76,7 +76,7 @@ export default class SpanContext implements Context {
       });
 
       if (carrier && carrier.isValid()) {
-        span.inject(carrier);
+        span.extract(carrier);
       }
     }
 
@@ -109,7 +109,7 @@ export default class SpanContext implements Context {
       });
 
       // if (carrier && carrier.isValid()) {  // is this right?
-      //   Object.assign(carrier, span.extract());
+      //   Object.assign(carrier, span.inject());
       // }
     }
 

--- a/src/trace/span/DummySpan.ts
+++ b/src/trace/span/DummySpan.ts
@@ -18,5 +18,14 @@
  */
 
 import Span from '../../trace/span/Span';
+import { ContextCarrier } from '../context/ContextCarrier';
 
-export default class DummySpan extends Span {}
+export default class DummySpan extends Span {
+  inject(): ContextCarrier {
+    return new ContextCarrier();
+  }
+
+  extract(carrier: ContextCarrier): this {
+    return this;
+  }
+}

--- a/src/trace/span/EntrySpan.ts
+++ b/src/trace/span/EntrySpan.ts
@@ -42,8 +42,8 @@ export default class EntrySpan extends StackedSpan {
     return this;
   }
 
-  inject(carrier: ContextCarrier): this {
-    super.inject(carrier);
+  extract(carrier: ContextCarrier): this {
+    super.extract(carrier);
 
     const ref = SegmentRef.fromCarrier(carrier);
 

--- a/src/trace/span/ExitSpan.ts
+++ b/src/trace/span/ExitSpan.ts
@@ -33,7 +33,7 @@ export default class ExitSpan extends StackedSpan {
     );
   }
 
-  extract(): ContextCarrier {
+  inject(): ContextCarrier {
     return new ContextCarrier(
       this.context.segment.relatedTraces[0],
       this.context.segment.segmentId,

--- a/src/trace/span/Span.ts
+++ b/src/trace/span/Span.ts
@@ -80,9 +80,6 @@ export default abstract class Span {
 
   stop(): this {
     logger.debug(`Stopping span ${this.operation}`, this);
-    if (this.operation === '/test') {
-      console.info('kkkkkkkkkkkkkkkkkkkkkkkkkl')
-    }
     this.context.stop(this);
     return this;
   }

--- a/src/trace/span/Span.ts
+++ b/src/trace/span/Span.ts
@@ -104,14 +104,14 @@ export default abstract class Span {
   }
 
   // noinspection JSUnusedLocalSymbols
-  extract(): ContextCarrier {
+  inject(): ContextCarrier {
     throw new Error(`
-      can only extract context carrier into ExitSpan, this may be a potential bug in the agent,
+      can only inject context carrier into ExitSpan, this may be a potential bug in the agent,
       please report this in ${packageInfo.bugs.url} if you encounter this.
     `);
   }
 
-  inject(carrier: ContextCarrier): this {
+  extract(carrier: ContextCarrier): this {
     this.context.segment.relate(carrier.traceId!);
 
     return this;

--- a/src/trace/span/StackedSpan.ts
+++ b/src/trace/span/StackedSpan.ts
@@ -38,7 +38,10 @@ export default class StackedSpan extends Span {
     return this;
   }
 
-  finish(segment: Segment): boolean {
-    return --this.depth === 0 && super.finish(segment);
+  stop(): this {
+    if (--this.depth === 0) {
+      super.stop();
+    }
+    return this;
   }
 }

--- a/tests/plugins/http/expected.data.yaml
+++ b/tests/plugins/http/expected.data.yaml
@@ -31,7 +31,7 @@ segmentItems:
             componentId: 49
             isError: false
             spanType: Entry
-            peer: ''
+            peer: server:5000
             skipAnalysis: false
             tags:
               - { key: http.url, value: server:5000/test }
@@ -71,7 +71,7 @@ segmentItems:
             componentId: 49
             isError: false
             spanType: Entry
-            peer: ''
+            peer: localhost:5001
             skipAnalysis: false
             tags:
               - { key: http.url, value: localhost:5001/test }


### PR DESCRIPTION
* Fixed nested Entry and Exit spans, before they did not at all.
* Fixed DummySpan - override `inject()` and `extract()`.
* Fixed PluginInstaller - previously did not load non-builtin modules correctly, also now wraps plugin install in try / catch.
* Fixed HttpPlugin - now storing peer.
* Changed `StackedSpan` to track nested depth more clearly through `start()` and `stop()` instead of `finish()`.
* Changed `inject()` and `extract()` functions to have the same meaning as Python agent.
* Added https plugin.
* Added express plugin.
* Added axios plugin.
