### PR TITLE
Update submodule over https instead of ssh in case of no ssh is configured

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "protocol"]
 	path = protocol
-	url = git@github.com:apache/skywalking-data-collect-protocol.git
+	url = https://github.com/apache/skywalking-data-collect-protocol.git


### PR DESCRIPTION
Developers/CI machines where no ssh is configured, it failed to update the submodule