### PR TITLE
Fixing async and preparing child entry/exit

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,8 @@ Environment Variable | Description | Default
 | `SW_AGENT_INSTANCE` | The name of the service instance | Randomly generated |
 | `SW_AGENT_COLLECTOR_BACKEND_SERVICES` | The backend OAP server address | `127.0.0.1:11800` |
 | `SW_AGENT_AUTHENTICATION` | The authentication token to verify that the agent is trusted by the backend OAP, as for how to configure the backend, refer to [the yaml](https://github.com/apache/skywalking/blob/4f0f39ffccdc9b41049903cc540b8904f7c9728e/oap-server/server-bootstrap/src/main/resources/application.yml#L155-L158). | not set |
-| `SW_AGENT_LOGGING_LEVEL` | The logging level, could be one of `CRITICAL`, `FATAL`, `ERROR`, `WARN`(`WARNING`), `INFO`, `DEBUG` | `INFO` |
+| `SW_AGENT_LOGGING_LEVEL` | The logging level, could be one of `error`, `warn`, `info`, `debug` | `info` |
+| `SW_AGENT_DISABLE_PLUGINS` | Comma-delimited list of plugins to disable in the plugins directory (e.g. "mysql", "express"). | `` |
 | `SW_IGNORE_SUFFIX` | The suffices of endpoints that will be ignored (not traced), comma separated | `.jpg,.jpeg,.js,.css,.png,.bmp,.gif,.ico,.mp3,.mp4,.html,.svg` |
 | `SW_TRACE_IGNORE_PATH` | The paths of endpoints that will be ignored (not traced), comma separated | `` |
 | `SW_SQL_TRACE_PARAMETERS` | If set to 'true' then SQL query parameters will be included | `false` |

--- a/src/core/PluginInstaller.ts
+++ b/src/core/PluginInstaller.ts
@@ -22,6 +22,7 @@ import * as path from 'path';
 import SwPlugin from '../core/SwPlugin';
 import { createLogger } from '../logging';
 import * as semver from 'semver';
+import config from '../config/AgentConfig';
 
 const logger = createLogger(__filename);
 
@@ -76,6 +77,11 @@ export default class PluginInstaller {
     fs.readdirSync(this.pluginDir)
     .filter((file) => !(file.endsWith('.d.ts') || file.endsWith('.js.map')))
     .forEach((file) => {
+      if (file.match(config.reDisablePlugins)) {
+        logger.info(`Plugin ${file} not installed because it is disabled`);
+        return;
+      }
+
       let plugin;
       const pluginFile = path.join(this.pluginDir, file);
 

--- a/src/plugins/AMQPLibPlugin.ts
+++ b/src/plugins/AMQPLibPlugin.ts
@@ -44,7 +44,7 @@ class AMQPLibPlugin implements SwPlugin {
       const queue = fields.routingKey || '';
       const peer = `${this.connection.stream.remoteAddress}:${this.connection.stream.remotePort}`;
 
-      const span = ContextManager.current.newExitSpan('RabbitMQ/' + topic + '/' + queue + '/Producer', peer).start();
+      const span = ContextManager.current.newExitSpan('RabbitMQ/' + topic + '/' + queue + '/Producer', peer, Component.RABBITMQ_PRODUCER).start();
 
       try {
         span.inject().items.forEach((item) => {

--- a/src/plugins/AxiosPlugin.ts
+++ b/src/plugins/AxiosPlugin.ts
@@ -39,7 +39,7 @@ class AxiosPlugin implements SwPlugin {
 
     defaults.adapter = (config: any) => {
       const { host, pathname: operation } = new URL(config.url);  // TODO: this may throw invalid URL
-      const span = ContextManager.current.newExitSpan(operation, host).start();
+      const span = ContextManager.current.newExitSpan(operation, host, Component.AXIOS, Component.HTTP).start();
 
       let ret: any;
 

--- a/src/plugins/AxiosPlugin.ts
+++ b/src/plugins/AxiosPlugin.ts
@@ -41,6 +41,8 @@ class AxiosPlugin implements SwPlugin {
       const { host, pathname: operation } = new URL(config.url);  // TODO: this may throw invalid URL
       const span = ContextManager.current.newExitSpan(operation, host).start();
 
+      let ret: any;
+
       try {
         span.component = Component.AXIOS;
         span.layer = SpanLayer.HTTP;
@@ -51,7 +53,7 @@ class AxiosPlugin implements SwPlugin {
           config.headers[item.key] = item.value;
         });
 
-        const copyStatusAndStop = (response: any) => {
+        const copyStatus = (response: any) => {
           if (response) {
             if (response.status) {
               span.tag(Tag.httpStatusCode(response.status));
@@ -64,20 +66,20 @@ class AxiosPlugin implements SwPlugin {
               span.tag(Tag.httpStatusMsg(response.statusText));
             }
           }
-
-          span.stop();
         };
 
-        return defaultAdapter(config).then(
+        ret = defaultAdapter(config).then(
           (response: any) => {
-            copyStatusAndStop(response);
+            copyStatus(response);
+            span.stop();
 
             return response;
           },
 
           (error: any) => {
+            copyStatus(error.response);
             span.error(error);
-            copyStatusAndStop(error.response);
+            span.stop();
 
             return Promise.reject(error);
           }
@@ -89,6 +91,10 @@ class AxiosPlugin implements SwPlugin {
 
         throw e;
       }
+
+      span.async();
+
+      return ret;
     }
   }
 }

--- a/src/plugins/ExpressPlugin.ts
+++ b/src/plugins/ExpressPlugin.ts
@@ -59,7 +59,7 @@ class ExpressPlugin implements SwPlugin {
           if (res.statusCode && res.statusCode >= 400) {
             span.errored = true;
           }
-          if (err) {
+          if (err instanceof Error) {
             span.error(err);
           }
           if (res.statusMessage) {

--- a/src/plugins/ExpressPlugin.ts
+++ b/src/plugins/ExpressPlugin.ts
@@ -49,7 +49,7 @@ class ExpressPlugin implements SwPlugin {
 
       const carrier = ContextCarrier.from(headersMap);
       const operation = (req.url || '/').replace(/\?.*/g, '');
-      const span = ContextManager.current.newEntrySpan(operation, carrier).start();
+      const span = ContextManager.current.newEntrySpan(operation, carrier, Component.HTTP_SERVER).start();
 
       let stopped = 0;
       const stopIfNotStopped = (err: Error | null) => {

--- a/src/plugins/HttpPlugin.ts
+++ b/src/plugins/HttpPlugin.ts
@@ -198,7 +198,7 @@ class HttpPlugin implements SwPlugin {
             span.stop();
           };
 
-          res.on('close', copyStatusAndStopIfNotStopped);
+          req.on('end', copyStatusAndStopIfNotStopped);  // this insead of 'close' because Node 10 doesn't emit those
           res.on('abort', () => (span.errored = true, span.log('Abort', true), copyStatusAndStopIfNotStopped()));
           res.on('error', (err) => (span.error(err), copyStatusAndStopIfNotStopped()));
 

--- a/src/plugins/HttpPlugin.ts
+++ b/src/plugins/HttpPlugin.ts
@@ -62,7 +62,7 @@ class HttpPlugin implements SwPlugin {
 
       let stopped = 0;  // compensating if request aborted right after creation 'close' is not emitted
       const stopIfNotStopped = () => !stopped++ ? span.stop() : null;  // make sure we stop only because other events may proc along with req.'close'
-      const span: ExitSpan = ContextManager.current.newExitSpan(operation, host).start() as ExitSpan;
+      const span: ExitSpan = ContextManager.current.newExitSpan(operation, host, Component.HTTP).start() as ExitSpan;
 
       try {
         if (span.depth === 1) {  // only set HTTP if this span is not overridden by a higher level one

--- a/src/plugins/HttpPlugin.ts
+++ b/src/plugins/HttpPlugin.ts
@@ -81,10 +81,6 @@ class HttpPlugin implements SwPlugin {
 
         const req: ClientRequest = _request.apply(this, arguments);
 
-
-        // TODO: req = http.request(...).on('response') if no callback provided.
-
-
         span.inject().items.forEach((item) => {
           req.setHeader(item.key, item.value);
         });
@@ -132,10 +128,6 @@ class HttpPlugin implements SwPlugin {
 
               } catch (err) {
                 span.error(err);
-
-
-                // TODO: sometimes not exiting
-
 
                 throw err;
 

--- a/src/plugins/MongoDBPlugin.ts
+++ b/src/plugins/MongoDBPlugin.ts
@@ -41,13 +41,11 @@ class MongoDBPlugin implements SwPlugin {
       return false;
 
     cursor.on('error', (err: any) => {
-      // span.resync();  // this may precede 'close' .resync() but its fine
       span.error(err);
       span.stop();
     });
 
     cursor.on('close', () => {
-      // span.resync();  // cursor does not .resync() until it is closed because maybe other exit spans will be opened during processing
       span.stop();
     });
 
@@ -67,8 +65,6 @@ class MongoDBPlugin implements SwPlugin {
 
       args[idx] = function(this: any, error: any, result: any) {
         if (error || !plugin.maybeHookCursor(span, result)) {
-          // span.resync();
-
           if (error)
             span.error(error);
 
@@ -242,7 +238,7 @@ class MongoDBPlugin implements SwPlugin {
         host = '???';
       }
 
-      span = ContextManager.current.newExitSpan('MongoDB/' + operation, host).start();
+      span = ContextManager.current.newExitSpan('MongoDB/' + operation, host, Component.MONGODB).start();
 
       try {
         span.component = Component.MONGODB;
@@ -268,14 +264,12 @@ class MongoDBPlugin implements SwPlugin {
           } else {
             ret = ret.then(
               (res: any) => {
-                // span.resync();
                 span.stop();
 
                 return res;
               },
 
               (err: any) => {
-                // span.resync();
                 span.error(err);
                 span.stop();
 

--- a/src/plugins/MongoDBPlugin.ts
+++ b/src/plugins/MongoDBPlugin.ts
@@ -41,13 +41,13 @@ class MongoDBPlugin implements SwPlugin {
       return false;
 
     cursor.on('error', (err: any) => {
-      span.resync();  // this may precede 'close' .resync() but its fine
+      // span.resync();  // this may precede 'close' .resync() but its fine
       span.error(err);
       span.stop();
     });
 
     cursor.on('close', () => {
-      span.resync();  // cursor does not .resync() until it is closed because maybe other exit spans will be opened during processing
+      // span.resync();  // cursor does not .resync() until it is closed because maybe other exit spans will be opened during processing
       span.stop();
     });
 
@@ -67,7 +67,7 @@ class MongoDBPlugin implements SwPlugin {
 
       args[idx] = function(this: any, error: any, result: any) {
         if (error || !plugin.maybeHookCursor(span, result)) {
-          span.resync();
+          // span.resync();
 
           if (error)
             span.error(error);
@@ -268,14 +268,14 @@ class MongoDBPlugin implements SwPlugin {
           } else {
             ret = ret.then(
               (res: any) => {
-                span.resync();
+                // span.resync();
                 span.stop();
 
                 return res;
               },
 
               (err: any) => {
-                span.resync();
+                // span.resync();
                 span.error(err);
                 span.stop();
 

--- a/src/plugins/MongoDBPlugin.ts
+++ b/src/plugins/MongoDBPlugin.ts
@@ -83,8 +83,8 @@ class MongoDBPlugin implements SwPlugin {
 
       let str = JSON.stringify(params);
 
-      if (str.length > agentConfig.mongo_parameters_max_length)
-        str = str.slice(0, agentConfig.mongo_parameters_max_length) + ' ...';
+      if (str.length > agentConfig.mongoParametersMaxLength)
+        str = str.slice(0, agentConfig.mongoParametersMaxLength) + ' ...';
 
       return str;
     }
@@ -92,7 +92,7 @@ class MongoDBPlugin implements SwPlugin {
     const insertFunc = function(this: any, operation: string, span: any, args: any[]): boolean {  // args = [doc(s), options, callback]
       span.tag(Tag.dbStatement(`${this.s.namespace.collection}.${operation}()`));
 
-      if (agentConfig.mongo_trace_parameters)
+      if (agentConfig.mongoTraceParameters)
         span.tag(Tag.dbMongoParameters(stringify(args[0])));
 
       return wrapCallback(span, args, 1);
@@ -107,7 +107,7 @@ class MongoDBPlugin implements SwPlugin {
     const updateFunc = function(this: any, operation: string, span: any, args: any[]): boolean {  // args = [filter, update, options, callback]
       span.tag(Tag.dbStatement(`${this.s.namespace.collection}.${operation}(${stringify(args[0])})`));
 
-      if (agentConfig.mongo_trace_parameters)
+      if (agentConfig.mongoTraceParameters)
         span.tag(Tag.dbMongoParameters(stringify(args[1])));
 
       return wrapCallback(span, args, 2);
@@ -132,7 +132,7 @@ class MongoDBPlugin implements SwPlugin {
         params += ', ' + stringify(args[1]);
 
         if (typeof args[2] !== 'function' && args[2] !== undefined) {
-          if (agentConfig.mongo_trace_parameters)
+          if (agentConfig.mongoTraceParameters)
             span.tag(Tag.dbMongoParameters(stringify(args[2])));
         }
       }

--- a/src/plugins/MySQLPlugin.ts
+++ b/src/plugins/MySQLPlugin.ts
@@ -36,8 +36,6 @@ class MySQLPlugin implements SwPlugin {
     Connection.prototype.query = function(sql: any, values: any, cb: any) {
       const wrapCallback = (_cb: any) => {
         return function(this: any, error: any, results: any, fields: any) {
-          // span.resync();
-
           if (error)
             span.error(error);
 
@@ -50,7 +48,7 @@ class MySQLPlugin implements SwPlugin {
       let query: any;
 
       const host = `${this.config.host}:${this.config.port}`;
-      const span = ContextManager.current.newExitSpan('mysql/query', host).start();
+      const span = ContextManager.current.newExitSpan('mysql/query', host, Component.MYSQL).start();
 
       try {
         span.component = Component.MYSQL;
@@ -122,12 +120,10 @@ class MySQLPlugin implements SwPlugin {
 
         if (streaming) {
           query.on('error', (e: any) => {
-            // span.resync();
             span.error(e);
           });
 
           query.on('end', () => {
-            // span.resync();  // may have already been done in 'error' but safe to do multiple times
             span.stop()
           });
         }

--- a/src/plugins/MySQLPlugin.ts
+++ b/src/plugins/MySQLPlugin.ts
@@ -36,7 +36,7 @@ class MySQLPlugin implements SwPlugin {
     Connection.prototype.query = function(sql: any, values: any, cb: any) {
       const wrapCallback = (_cb: any) => {
         return function(this: any, error: any, results: any, fields: any) {
-          span.resync();
+          // span.resync();
 
           if (error)
             span.error(error);
@@ -122,12 +122,12 @@ class MySQLPlugin implements SwPlugin {
 
         if (streaming) {
           query.on('error', (e: any) => {
-            span.resync();
+            // span.resync();
             span.error(e);
           });
 
           query.on('end', () => {
-            span.resync();  // may have already been done in 'error' but safe to do multiple times
+            // span.resync();  // may have already been done in 'error' but safe to do multiple times
             span.stop()
           });
         }

--- a/src/plugins/MySQLPlugin.ts
+++ b/src/plugins/MySQLPlugin.ts
@@ -107,11 +107,11 @@ class MySQLPlugin implements SwPlugin {
 
         span.tag(Tag.dbStatement(`${_sql}`));
 
-        if (agentConfig.sql_trace_parameters && _values) {
+        if (agentConfig.sqlTraceParameters && _values) {
           let vals = _values.map((v: any) => v === undefined ? 'undefined' : JSON.stringify(v)).join(', ');
 
-          if (vals.length > agentConfig.sql_parameters_max_length)
-            vals = vals.slice(0, agentConfig.sql_parameters_max_length) + ' ...';
+          if (vals.length > agentConfig.sqlParametersMaxLength)
+            vals = vals.slice(0, agentConfig.sqlParametersMaxLength) + ' ...';
 
           span.tag(Tag.dbSqlParameters(`[${vals}]`));
         }

--- a/src/plugins/PgPlugin.ts
+++ b/src/plugins/PgPlugin.ts
@@ -43,7 +43,7 @@ class MySQLPlugin implements SwPlugin {
     Client.prototype.query = function(config: any, values: any, callback: any) {
       const wrapCallback = (_cb: any) => {
         return function(this: any, err: any, res: any) {
-          span.resync();
+          // span.resync();
 
           if (err)
             span.error(err);
@@ -105,27 +105,27 @@ class MySQLPlugin implements SwPlugin {
         if (query) {
           if (Cursor && query instanceof Cursor) {
             query.on('error', (err: any) => {
-              span.resync();  // this may precede 'end' .resync() but its fine
+              // span.resync();  // this may precede 'end' .resync() but its fine
               span.error(err);
               span.stop();
             });
 
             query.on('end', () => {
-              span.resync();  // cursor does not .resync() until it is closed because maybe other exit spans will be opened during processing
+              // span.resync();  // cursor does not .resync() until it is closed because maybe other exit spans will be opened during processing
               span.stop();
             });
 
           } else if (typeof query.then === 'function') {  // generic Promise check
             query = query.then(
               (res: any) => {
-                span.resync();
+                // span.resync();
                 span.stop();
 
                 return res;
               },
 
               (err: any) => {
-                span.resync();
+                // span.resync();
                 span.error(err);
                 span.stop();
 

--- a/src/plugins/PgPlugin.ts
+++ b/src/plugins/PgPlugin.ts
@@ -89,11 +89,11 @@ class MySQLPlugin implements SwPlugin {
 
         span.tag(Tag.dbStatement(`${_sql}`));
 
-        if (agentConfig.sql_trace_parameters && _values) {
+        if (agentConfig.sqlTraceParameters && _values) {
           let vals = _values.map((v: any) => v === undefined ? 'undefined' : JSON.stringify(v)).join(', ');
 
-          if (vals.length > agentConfig.sql_parameters_max_length)
-            vals = vals.slice(0, agentConfig.sql_parameters_max_length) + ' ...';
+          if (vals.length > agentConfig.sqlParametersMaxLength)
+            vals = vals.slice(0, agentConfig.sqlParametersMaxLength) + ' ...';
 
             span.tag(Tag.dbSqlParameters(`[${vals}]`));
         }

--- a/src/trace/context/Context.ts
+++ b/src/trace/context/Context.ts
@@ -19,6 +19,7 @@
 
 import Span from '../../trace/span/Span';
 import Segment from '../../trace/context/Segment';
+import { Component } from '../../trace/Component';
 import { ContextCarrier } from './ContextCarrier';
 
 export default interface Context {
@@ -26,9 +27,15 @@ export default interface Context {
 
   newLocalSpan(operation: string): Span;
 
-  newEntrySpan(operation: string, carrier?: ContextCarrier): Span;
+  /* If 'inherit' is specified then if the span at the top of the stack is an Entry span of this component type then the
+     span is reused instead of a new child span being created. This is intended for situations like an express handler
+     inheriting an opened incoming http connection to present a single span. */
+  newEntrySpan(operation: string, carrier?: ContextCarrier, inherit?: Component): Span;
 
-  newExitSpan(operation: string, peer: string): Span;
+  /* if 'inherit' is specified then the span returned is marked for inheritance by an Exit span component which is
+     created later and calls this function with a matching 'component' value. For example Axios using an Http exit
+     connection will be merged into a single exit span, see those plugins for how this is done. */
+  newExitSpan(operation: string, peer: string, component: Component, inherit?: Component): Span;
 
   start(span: Span): Context;
 

--- a/src/trace/context/DummyContext.ts
+++ b/src/trace/context/DummyContext.ts
@@ -21,6 +21,7 @@ import Context from '../../trace/context/Context';
 import Span from '../../trace/span/Span';
 import DummySpan from '../../trace/span/DummySpan';
 import Segment from '../../trace/context/Segment';
+import { Component } from '../../trace/Component';
 import { SpanType } from '../../proto/language-agent/Tracing_pb';
 import { ContextCarrier } from './ContextCarrier';
 
@@ -33,11 +34,11 @@ export default class DummyContext implements Context {
   segment: Segment = new Segment();
   depth = 0;
 
-  newEntrySpan(operation: string, carrier?: ContextCarrier): Span {
+  newEntrySpan(operation: string, carrier?: ContextCarrier, inherit?: Component): Span {
     return this.span;
   }
 
-  newExitSpan(operation: string, peer: string): Span {
+  newExitSpan(operation: string, peer: string, component: Component, inherit?: Component): Span {
     return this.span;
   }
 

--- a/src/trace/context/SpanContext.ts
+++ b/src/trace/context/SpanContext.ts
@@ -26,6 +26,7 @@ import Segment from '../../trace/context/Segment';
 import EntrySpan from '../../trace/span/EntrySpan';
 import ExitSpan from '../../trace/span/ExitSpan';
 import LocalSpan from '../../trace/span/LocalSpan';
+import { Component } from '../../trace/Component';
 import { createLogger } from '../../logging';
 import { executionAsyncId } from 'async_hooks';
 import { ContextCarrier } from './ContextCarrier';
@@ -63,7 +64,7 @@ export default class SpanContext implements Context {
     return undefined;
   }
 
-  newEntrySpan(operation: string, carrier?: ContextCarrier): Span {
+  newEntrySpan(operation: string, carrier?: ContextCarrier, inherit?: Component): Span {
     let span = this.ignoreCheck(operation, SpanType.ENTRY);
 
     if (span)
@@ -79,7 +80,7 @@ export default class SpanContext implements Context {
       });
     }
 
-    if (parent && parent.type === SpanType.ENTRY) {
+    if (parent && parent.type === SpanType.ENTRY && inherit && inherit === parent.component) {
       span = parent;
       parent.operation = operation;
 
@@ -99,7 +100,7 @@ export default class SpanContext implements Context {
     return span;
   }
 
-  newExitSpan(operation: string, peer: string): Span {
+  newExitSpan(operation: string, peer: string, component: Component, inherit?: Component): Span {
     let span = this.ignoreCheck(operation, SpanType.EXIT);
 
     if (span)
@@ -117,7 +118,7 @@ export default class SpanContext implements Context {
       });
     }
 
-    if (parent && parent.type === SpanType.EXIT) {
+    if (parent && parent.type === SpanType.EXIT && component === parent.inherit) {
       span = parent;
 
     } else {
@@ -129,6 +130,9 @@ export default class SpanContext implements Context {
         operation,
       });
     }
+
+    if (inherit)
+      span.inherit = inherit;
 
     return span;
   }

--- a/src/trace/span/Span.ts
+++ b/src/trace/span/Span.ts
@@ -50,6 +50,7 @@ export default abstract class Span {
   operation: string;
   layer = SpanLayer.UNKNOWN;
   component = Component.UNKNOWN;
+  inherit?: Component;
 
   readonly tags: Tag[] = [];
   readonly logs: Log[] = [];

--- a/tests/plugins/axios/expected.data.yaml
+++ b/tests/plugins/axios/expected.data.yaml
@@ -21,26 +21,6 @@ segmentItems:
     segments:
       - segmentId: not null
         spans:
-          - operationName: /json
-            operationId: 0
-            parentSpanId: 0
-            spanId: 1
-            spanLayer: Http
-            startTime: gt 0
-            endTime: gt 0
-            componentId: 4005
-            spanType: Exit
-            peer: httpbin.org
-            skipAnalysis: false
-            tags:
-              - key: http.url
-                value: httpbin.org/json
-              - key: http.method
-                value: GET
-              - key: http.status.code
-                value: '200'
-              - key: http.status.msg
-                value: OK
           - operationName: /axios
             operationId: 0
             parentSpanId: -1
@@ -70,31 +50,31 @@ segmentItems:
                 parentServiceInstance: not null
                 parentService: client
                 traceId: not null
-  - serviceName: client
-    segmentSize: 1
-    segments:
-      - segmentId: not null
-        spans:
-          - operationName: /axios
+          - operationName: /json
             operationId: 0
             parentSpanId: 0
             spanId: 1
             spanLayer: Http
+            startTime: gt 0
+            endTime: gt 0
+            componentId: 4005
+            spanType: Exit
+            peer: httpbin.org
+            skipAnalysis: false
             tags:
               - key: http.url
-                value: server:5000/axios
+                value: httpbin.org/json
               - key: http.method
                 value: GET
               - key: http.status.code
                 value: '200'
               - key: http.status.msg
                 value: OK
-            startTime: gt 0
-            endTime: gt 0
-            componentId: 4005
-            spanType: Exit
-            peer: server:5000
-            skipAnalysis: false
+  - serviceName: client
+    segmentSize: 1
+    segments:
+      - segmentId: not null
+        spans:
           - operationName: /axios
             operationId: 0
             parentSpanId: -1
@@ -114,4 +94,24 @@ segmentItems:
             componentId: 49
             spanType: Entry
             peer: not null
+            skipAnalysis: false
+          - operationName: /axios
+            operationId: 0
+            parentSpanId: 0
+            spanId: 1
+            spanLayer: Http
+            tags:
+              - key: http.url
+                value: server:5000/axios
+              - key: http.method
+                value: GET
+              - key: http.status.code
+                value: '200'
+              - key: http.status.msg
+                value: OK
+            startTime: gt 0
+            endTime: gt 0
+            componentId: 4005
+            spanType: Exit
+            peer: server:5000
             skipAnalysis: false

--- a/tests/plugins/express/expected.data.yaml
+++ b/tests/plugins/express/expected.data.yaml
@@ -21,26 +21,6 @@ segmentItems:
     segments:
       - segmentId: not null
         spans:
-          - operationName: /json
-            operationId: 0
-            parentSpanId: 0
-            spanId: 1
-            spanLayer: Http
-            startTime: gt 0
-            endTime: gt 0
-            componentId: 2
-            spanType: Exit
-            peer: httpbin.org
-            skipAnalysis: false
-            tags:
-              - key: http.url
-                value: httpbin.org/json
-              - key: http.method
-                value: GET
-              - key: http.status.code
-                value: '200'
-              - key: http.status.msg
-                value: OK
           - operationName: /express
             operationId: 0
             parentSpanId: -1
@@ -70,31 +50,31 @@ segmentItems:
             spanType: Entry
             peer: not null
             skipAnalysis: false
-  - serviceName: client
-    segmentSize: 1
-    segments:
-      - segmentId: not null
-        spans:
-          - operationName: /express
+          - operationName: /json
             operationId: 0
             parentSpanId: 0
             spanId: 1
             spanLayer: Http
+            startTime: gt 0
+            endTime: gt 0
+            componentId: 2
+            spanType: Exit
+            peer: httpbin.org
+            skipAnalysis: false
             tags:
               - key: http.url
-                value: server:5000/express
+                value: http://httpbin.org/json
               - key: http.method
                 value: GET
               - key: http.status.code
                 value: '200'
               - key: http.status.msg
                 value: OK
-            startTime: gt 0
-            endTime: gt 0
-            componentId: 2
-            spanType: Exit
-            peer: server:5000
-            skipAnalysis: false
+  - serviceName: client
+    segmentSize: 1
+    segments:
+      - segmentId: not null
+        spans:
           - operationName: /express
             operationId: 0
             parentSpanId: -1
@@ -114,4 +94,24 @@ segmentItems:
             componentId: 4002
             spanType: Entry
             peer: not null
+            skipAnalysis: false
+          - operationName: /express
+            operationId: 0
+            parentSpanId: 0
+            spanId: 1
+            spanLayer: Http
+            tags:
+              - key: http.url
+                value: http://server:5000/express
+              - key: http.method
+                value: GET
+              - key: http.status.code
+                value: '200'
+              - key: http.status.msg
+                value: OK
+            startTime: gt 0
+            endTime: gt 0
+            componentId: 2
+            spanType: Exit
+            peer: server:5000
             skipAnalysis: false

--- a/tests/plugins/http/expected.data.yaml
+++ b/tests/plugins/http/expected.data.yaml
@@ -39,6 +39,8 @@ segmentItems:
                 value: GET
               - key: http.status.code
                 value: '200'
+              - key: http.status.msg
+                value: OK
             refs:
               - parentEndpoint: ''
                 networkAddress: server:5000
@@ -91,6 +93,8 @@ segmentItems:
                 value: GET
               - key: http.status.code
                 value: '200'
+              - key: http.status.msg
+                value: OK
           - operationName: /test
             operationId: 0
             parentSpanId: 0

--- a/tests/plugins/http/expected.data.yaml
+++ b/tests/plugins/http/expected.data.yaml
@@ -61,7 +61,7 @@ segmentItems:
             skipAnalysis: false
             tags:
               - key: http.url
-                value: httpbin.org/json
+                value: http://httpbin.org/json
               - key: http.method
                 value: GET
               - key: http.status.code
@@ -104,7 +104,7 @@ segmentItems:
             skipAnalysis: false
             tags:
               - key: http.url
-                value: server:5000/test
+                value: http://server:5000/test
               - key: http.method
                 value: GET
               - key: http.status.code

--- a/tests/plugins/mongodb/expected.data.yaml
+++ b/tests/plugins/mongodb/expected.data.yaml
@@ -81,6 +81,7 @@ segmentItems:
               - { key: http.url, value: 'http://localhost:5001/mongo' }
               - { key: http.method, value: GET }
               - { key: http.status.code, value: '200' }
+              - { key: http.status.msg, value: OK }
           - operationName: /mongo
             operationId: 0
             parentSpanId: 0
@@ -93,7 +94,7 @@ segmentItems:
             peer: server:5000
             skipAnalysis: false
             tags:
-              - { key: http.url, value: 'server:5000/mongo' }
+              - { key: http.url, value: 'http://server:5000/mongo' }
               - { key: http.method, value: GET }
               - { key: http.status.code, value: '200' }
               - { key: http.status.msg, value: OK }

--- a/tests/plugins/mysql/expected.data.yaml
+++ b/tests/plugins/mysql/expected.data.yaml
@@ -21,33 +21,6 @@ segmentItems:
     segments:
       - segmentId: not null
         spans:
-          - operationName: /mysql
-            operationId: 0
-            parentSpanId: -1
-            spanId: 0
-            spanLayer: Http
-            startTime: gt 0
-            endTime: gt 0
-            componentId: 49
-            spanType: Entry
-            peer: not null
-            skipAnalysis: false
-            tags:
-              - key: http.url
-                value: http://server:5000/mysql
-              - key: http.method
-                value: GET
-              - key: http.status.code
-                value: "200"
-            refs:
-              - parentEndpoint: ""
-                networkAddress: server:5000
-                refType: CrossProcess
-                parentSpanId: 1
-                parentTraceSegmentId: not null
-                parentServiceInstance: not null
-                parentService: client
-                traceId: not null
           - operationName: mysql/query
             operationId: 0
             parentSpanId: 0
@@ -66,6 +39,35 @@ segmentItems:
                 value: test
               - key: db.statement
                 value: SELECT * FROM `user` WHERE `name` = "u1"
+          - operationName: /mysql
+            operationId: 0
+            parentSpanId: -1
+            spanId: 0
+            spanLayer: Http
+            startTime: gt 0
+            endTime: gt 0
+            componentId: 49
+            spanType: Entry
+            peer: not null
+            skipAnalysis: false
+            tags:
+              - key: http.url
+                value: http://server:5000/mysql
+              - key: http.method
+                value: GET
+              - key: http.status.code
+                value: "200"
+              - key: http.status.msg
+                value: OK
+            refs:
+              - parentEndpoint: ""
+                networkAddress: server:5000
+                refType: CrossProcess
+                parentSpanId: 1
+                parentTraceSegmentId: not null
+                parentServiceInstance: not null
+                parentService: client
+                traceId: not null
   - serviceName: client
     segmentSize: 1
     segments:
@@ -89,6 +91,8 @@ segmentItems:
                 value: GET
               - key: http.status.code
                 value: "200"
+              - key: http.status.msg
+                value: OK
           - operationName: /mysql
             operationId: 0
             parentSpanId: 0
@@ -102,7 +106,7 @@ segmentItems:
             skipAnalysis: false
             tags:
               - key: http.url
-                value: server:5000/mysql
+                value: http://server:5000/mysql
               - key: http.method
                 value: GET
               - key: http.status.code

--- a/tests/plugins/pg/expected.data.yaml
+++ b/tests/plugins/pg/expected.data.yaml
@@ -21,30 +21,6 @@ segmentItems:
     segments:
       - segmentId: not null
         spans:
-          - operationName: /postgres
-            operationId: 0
-            parentSpanId: -1
-            spanId: 0
-            spanLayer: Http
-            startTime: gt 0
-            endTime: gt 0
-            componentId: 49
-            spanType: Entry
-            peer: not null
-            skipAnalysis: false
-            tags:
-              - { key: http.url, value: 'http://server:5000/postgres' }
-              - { key: http.method, value: GET }
-              - { key: http.status.code, value: '200' }
-            refs:
-              - parentEndpoint: ""
-                networkAddress: server:5000
-                refType: CrossProcess
-                parentSpanId: 1
-                parentTraceSegmentId: not null
-                parentServiceInstance: not null
-                parentService: client
-                traceId: not null
           - operationName: pg/query
             operationId: 0
             parentSpanId: 0
@@ -60,6 +36,31 @@ segmentItems:
               - { key: db.type, value: PostgreSQL }
               - { key: db.instance, value: test }
               - { key: db.statement, value: SELECT * FROM "user" where name = 'u1' }
+          - operationName: /postgres
+            operationId: 0
+            parentSpanId: -1
+            spanId: 0
+            spanLayer: Http
+            startTime: gt 0
+            endTime: gt 0
+            componentId: 49
+            spanType: Entry
+            peer: not null
+            skipAnalysis: false
+            tags:
+              - { key: http.url, value: 'http://server:5000/postgres' }
+              - { key: http.method, value: GET }
+              - { key: http.status.code, value: '200' }
+              - { key: http.status.msg, value: OK }
+            refs:
+              - parentEndpoint: ""
+                networkAddress: server:5000
+                refType: CrossProcess
+                parentSpanId: 1
+                parentTraceSegmentId: not null
+                parentServiceInstance: not null
+                parentService: client
+                traceId: not null
   - serviceName: client
     segmentSize: 1
     segments:
@@ -80,6 +81,7 @@ segmentItems:
               - { key: http.url, value: 'http://localhost:5001/postgres' }
               - { key: http.method, value: GET }
               - { key: http.status.code, value: '200' }
+              - { key: http.status.msg, value: OK }
           - operationName: /postgres
             operationId: 0
             parentSpanId: 0
@@ -92,7 +94,7 @@ segmentItems:
             peer: server:5000
             skipAnalysis: false
             tags:
-              - { key: http.url, value: 'server:5000/postgres' }
+              - { key: http.url, value: 'http://server:5000/postgres' }
               - { key: http.method, value: GET }
               - { key: http.status.code, value: '200' }
               - { key: http.status.msg, value: OK }


### PR DESCRIPTION
The changes here are the result of preparing for allowing Exit/Exit and Entry/Entry parent child relationships during which I discovered and am in the process of fixing and improving some async functionality.

The source of the problem which necessitated #27 was discovered and fixed. The `http` and `axios` modules did not properly `async()` on returning a connection. Also, `async()` itself now duplicates the spans list for the current task in order that async tasks created before the `async()` don't have their copies of the list corrupted by subsequent operations in the current task. This all removes the necessity for a separate `invalid` flag, which flag itself was only a partial patch for the main problem which would still manifest in other ways.

The functionality of the `http` module is also being expanded so that errors on `'data'` events are properly attributed to the span.

Also, `span.resync()` no longer needed before `span.stop()`, a span can be errored or stopped while async.

Not for merge just yet.