### PR TITLE
HttpClient fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ Library | Underlying Plugin Name
 | [`request`](https://github.com/request/request) | `http` / `https` |
 | [`request-promise`](https://github.com/request/request-promise) | `http` / `https` |
 | [`koa`](https://github.com/koajs/koa) | `http` / `https` |
+| [`mongoose`](https://github.com/Automattic/mongoose) | `mongodb` |
 
 ## Contact Us
 * Submit [an issue](https://github.com/apache/skywalking/issues/new) by using [Nodejs] as title prefix.

--- a/src/core/SwPlugin.ts
+++ b/src/core/SwPlugin.ts
@@ -27,7 +27,8 @@ export default interface SwPlugin {
   install(installer: PluginInstaller): void;
 }
 
-export const wrapEmit = (span: Span, ee: any, doError: boolean = true, endEvent: any = NaN) => {  // because NaN !== NaN
+export const wrapEmit = (span: Span, ee: any, doError: boolean = true, stop: any = NaN) => {  // stop = NaN because NaN !== NaN
+  const stopIsFunc = typeof stop === 'function';
   const _emit = ee.emit;
 
   Object.defineProperty(ee, 'emit', {configurable: true, writable: true, value: (function(this: any): any {
@@ -47,7 +48,7 @@ export const wrapEmit = (span: Span, ee: any, doError: boolean = true, endEvent:
       throw err;
 
     } finally {
-      if (event === endEvent)
+      if (stopIsFunc ? stop(event) : event === stop)
         span.stop();
       else
         span.async();

--- a/src/plugins/HttpPlugin.ts
+++ b/src/plugins/HttpPlugin.ts
@@ -73,6 +73,43 @@ class HttpPlugin implements SwPlugin {
         span.tag(Tag.httpURL(protocol + '://' + host + pathname));
         span.tag(Tag.httpMethod(arguments[url instanceof URL || typeof url === 'string' ? 1 : 0]?.method || 'GET'));
 
+        const copyStatusAndWrapEmit = (res: any) => {
+          span.tag(Tag.httpStatusCode(res.statusCode));
+
+          if (res.statusCode && res.statusCode >= 400)
+            span.errored = true;
+
+          if (res.statusMessage)
+            span.tag(Tag.httpStatusMsg(res.statusMessage));
+
+            wrapEmit(span, res, false);
+        };
+
+        const responseCB = function(this: any, res: any) {  // may wrap callback instead of event because it procs first
+          span.resync();
+
+          copyStatusAndWrapEmit(res);
+
+          try {
+            if (callback)
+              return callback.apply(this, arguments);
+
+          } catch (err) {
+            span.error(err);
+
+            throw err;
+
+          } finally {
+            span.async();
+          }
+        };
+
+        const idxCallback = typeof arguments[2] === 'function' ? 2 : typeof arguments[1] === 'function' ? 1 : 0;
+        const callback    = arguments[idxCallback];
+
+        if (idxCallback)
+          arguments[idxCallback] = responseCB;
+
         const req: ClientRequest = _request.apply(this, arguments);
 
         span.inject().items.forEach((item) => req.setHeader(item.key, item.value));
@@ -82,17 +119,8 @@ class HttpPlugin implements SwPlugin {
         req.on('timeout', () => span.log('Timeout', true));
         req.on('abort', () => span.log('Abort', span.errored = true));
 
-        req.on('response', (res: any) => {
-          span.tag(Tag.httpStatusCode(res.statusCode));
-
-          if (res.statusCode && res.statusCode >= 400)
-            span.errored = true;
-
-          if (res.statusMessage)
-            span.tag(Tag.httpStatusMsg(res.statusMessage));
-
-          wrapEmit(span, res, false);
-        });
+        if (!idxCallback)
+          req.on('response', copyStatusAndWrapEmit);
 
         span.async();
 


### PR DESCRIPTION
Fixed two HttpClient edge cases:
* If an Exit span was created in an Entry span that is handling a "data" event then that child span would not be linked to the parent, like for example handling incoming POST data.
* Wrapped `http.request()` callback if one is provided instead of event since it procs before the event handler and the same kind of Exit span problem would occur if an Exit span was created in the callback.
