### PR TITLE
express uses http wrap explicitly if http disabled

### DIFF
--- a/src/trace/span/EntrySpan.ts
+++ b/src/trace/span/EntrySpan.ts
@@ -18,10 +18,9 @@
  */
 
 import StackedSpan from '../../trace/span/StackedSpan';
-import { Component } from '../Component';
 import { SpanCtorOptions } from './Span';
 import SegmentRef from '../../trace/context/SegmentRef';
-import { SpanLayer, SpanType } from '../../proto/language-agent/Tracing_pb';
+import { SpanType } from '../../proto/language-agent/Tracing_pb';
 import { ContextCarrier } from '../context/ContextCarrier';
 
 export default class EntrySpan extends StackedSpan {
@@ -31,15 +30,6 @@ export default class EntrySpan extends StackedSpan {
         type: SpanType.ENTRY,
       }),
     );
-  }
-
-  start(): this {
-    super.start();
-    this.layer = SpanLayer.UNKNOWN;
-    this.component = Component.UNKNOWN;
-    this.logs.splice(0, this.logs.length);
-    this.tags.splice(0, this.tags.length);
-    return this;
   }
 
   extract(carrier: ContextCarrier): this {


### PR DESCRIPTION
Another edge case and simplification. If the http plugin is disabled and a POST to express has a body then a span created in the handler would not be linked as a child to the express Entry span, now fixed. Basically just exported http server response wrapping code which already handled this fine and using that in express since don't really need to duplicate this functionality in express plugin.