### PR TITLE
BugFix: wrong context during many async spans

### DIFF
--- a/src/trace/context/Context.ts
+++ b/src/trace/context/Context.ts
@@ -24,6 +24,7 @@ import { ContextCarrier } from './ContextCarrier';
 
 export default interface Context {
   segment: Segment;
+  nSpans: number;
 
   newLocalSpan(operation: string): Span;
 

--- a/src/trace/context/DummyContext.ts
+++ b/src/trace/context/DummyContext.ts
@@ -32,7 +32,7 @@ export default class DummyContext implements Context {
     type: SpanType.LOCAL,
   });
   segment: Segment = new Segment();
-  depth = 0;
+  nSpans = 0;
 
   newEntrySpan(operation: string, carrier?: ContextCarrier, inherit?: Component): Span {
     return this.span;
@@ -47,12 +47,12 @@ export default class DummyContext implements Context {
   }
 
   start(): Context {
-    this.depth++;
+    this.nSpans++;
     return this;
   }
 
   stop(): boolean {
-    return --this.depth === 0;
+    return --this.nSpans === 0;
   }
 
   async(span: Span) {

--- a/src/trace/context/SpanContext.ts
+++ b/src/trace/context/SpanContext.ts
@@ -168,7 +168,7 @@ export default class SpanContext implements Context {
     });
 
     this.nSpans += 1;
-    if (ContextManager.spans.every((s) => s.id !== span.id)) {
+    if (ContextManager.spans.every((s) => s.id !== span.id || s.context !== span.context)) {
       ContextManager.spans.push(span);
     }
 
@@ -226,7 +226,7 @@ export default class SpanContext implements Context {
 
     if (!ContextManager.hasContext || !ContextManager.spans.length) {
       ContextManager.restore(span.context, [span]);
-    } else if (ContextManager.spans.every((s) => s.id !== span.id)) {
+    } else if (ContextManager.spans.every((s) => s.id !== span.id || s.context !== span.context)) {
       ContextManager.spans.push(span);
     }
   }


### PR DESCRIPTION
Found a bug during stress testing with many asynchronous spans with different contexts running concurrently. In that situation some child spans were being assigned wrong parents because of wrong `Context` at head of `asyncState`. Removed this redundant and potentially incorrect field and now just getting the current context from the topmost `Span` on the stack. Also added check for `context` as well as `id` to span add to stack in `SpanContext`.