### PR TITLE
Cold start detection and marking

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,8 @@ Environment Variable | Description | Default
 | `SW_AGENT_SECURE` | Whether to use secure connection to backend OAP server | `false` |
 | `SW_AGENT_AUTHENTICATION` | The authentication token to verify that the agent is trusted by the backend OAP, as for how to configure the backend, refer to [the yaml](https://github.com/apache/skywalking/blob/4f0f39ffccdc9b41049903cc540b8904f7c9728e/oap-server/server-bootstrap/src/main/resources/application.yml#L155-L158). | not set |
 | `SW_AGENT_LOGGING_LEVEL` | The logging level, could be one of `error`, `warn`, `info`, `debug` | `info` |
-| `SW_AGENT_DISABLE_PLUGINS` | Comma-delimited list of plugins to disable in the plugins directory (e.g. "mysql", "express"). | `` |
+| `SW_AGENT_DISABLE_PLUGINS` | Comma-delimited list of plugins to disable in the plugins directory (e.g. "mysql", "express") | `` |
+| `SW_COLD_ENDPOINT` | Cold start detection is as follows: First span to run within 1 second of skywalking init is considered a cold start. This span gets the tag `coldStart` set to 'true'. This span also optionally gets the text '\<cold\>' appended to the endpoint name if SW_COLD_ENDPOINT is set to 'true'. | `false` |
 | `SW_IGNORE_SUFFIX` | The suffices of endpoints that will be ignored (not traced), comma separated | `.jpg,.jpeg,.js,.css,.png,.bmp,.gif,.ico,.mp3,.mp4,.html,.svg` |
 | `SW_TRACE_IGNORE_PATH` | The paths of endpoints that will be ignored (not traced), comma separated | `` |
 | `SW_HTTP_IGNORE_METHOD` | Comma-delimited list of http methods to ignore (GET, POST, HEAD, OPTIONS, etc...) | `` |

--- a/src/Tag.ts
+++ b/src/Tag.ts
@@ -24,6 +24,7 @@ export interface Tag {
 }
 
 export default {
+  coldStartKey: 'coldStart',
   httpStatusCodeKey: 'http.status.code',  // TODO: maybe find a better place to put these?
   httpStatusMsgKey: 'http.status.msg',
   httpURLKey: 'http.url',
@@ -37,6 +38,13 @@ export default {
   mqTopicKey: 'mq.topic',
   mqQueueKey: 'mq.queue',
 
+  coldStart(val: boolean = true): Tag {
+    return {
+      key: this.coldStartKey,
+      overridable: true,
+      val: `${val}`,
+    } as Tag;
+  },
   httpStatusCode(val: string | number | undefined): Tag {
     return {
       key: this.httpStatusCodeKey,

--- a/src/azure/AzureHttpTriggerPlugin.ts
+++ b/src/azure/AzureHttpTriggerPlugin.ts
@@ -49,7 +49,7 @@ class AzureHttpTriggerPlugin {
         : ContextManager.current.newEntrySpan(operation, carrier);
 
       span.layer = SpanLayer.HTTP;
-      span.component = Component.AZURE_HTTPTRIGGER  ;
+      span.component = Component.AZURE_HTTPTRIGGER;
       span.peer = (req.headers['x-forwarded-for'] || '???').split(',').shift();
 
       span.tag(Tag.httpMethod(req.method));

--- a/src/config/AgentConfig.ts
+++ b/src/config/AgentConfig.ts
@@ -26,6 +26,7 @@ export type AgentConfig = {
   secure?: boolean;
   authorization?: string;
   maxBufferSize?: number;
+  coldEndpoint?: boolean;
   disablePlugins?: string;
   ignoreSuffix?: string;
   traceIgnorePath?: string;
@@ -66,10 +67,11 @@ const _config = {
       return os.hostname();
     })(),
   collectorAddress: process.env.SW_AGENT_COLLECTOR_BACKEND_SERVICES || '127.0.0.1:11800',
-  secure: process.env.SW_AGENT_SECURE?.toLocaleLowerCase() === 'true',
+  secure: process.env.SW_AGENT_SECURE?.toLowerCase() === 'true',
   authorization: process.env.SW_AGENT_AUTHENTICATION,
   maxBufferSize: Number.isSafeInteger(process.env.SW_AGENT_MAX_BUFFER_SIZE) ?
     Number.parseInt(process.env.SW_AGENT_MAX_BUFFER_SIZE as string, 10) : 1000,
+  coldEndpoint: process.env.SW_COLD_ENDPOINT?.toLowerCase() === 'true',
   disablePlugins: process.env.SW_AGENT_DISABLE_PLUGINS || '',
   ignoreSuffix: process.env.SW_IGNORE_SUFFIX ?? '.jpg,.jpeg,.js,.css,.png,.bmp,.gif,.ico,.mp3,.mp4,.html,.svg',
   traceIgnorePath: process.env.SW_TRACE_IGNORE_PATH || '',

--- a/src/trace/context/ContextManager.ts
+++ b/src/trace/context/ContextManager.ts
@@ -59,6 +59,19 @@ if (async_hooks.AsyncLocalStorage) {
 }
 
 class ContextManager {
+  isCold = true;
+
+  cosntructor() {
+    setTimeout(() => this.isCold = false, 1000).unref();
+  }
+
+  checkCold(): boolean {
+    const isCold = this.isCold;
+    this.isCold = false;
+
+    return isCold;
+  }
+
   get asyncState(): AsyncState {
     let asyncState = store.getStore();
 

--- a/src/trace/context/DummyContext.ts
+++ b/src/trace/context/DummyContext.ts
@@ -42,10 +42,12 @@ export default class DummyContext implements Context {
     return DummySpan.create(this);
   }
 
-  start(span: Span): Context {
+  start(span: DummySpan): Context {
     const spans = ContextManager.spansDup();
 
     if (!this.nSpans++) {
+      ContextManager.checkCold();  // set cold to false
+
       if (spans.indexOf(span) === -1)
         spans.push(span);
     }
@@ -53,7 +55,7 @@ export default class DummyContext implements Context {
     return this;
   }
 
-  stop(span: Span): boolean {
+  stop(span: DummySpan): boolean {
     if (--this.nSpans)
       return false;
 
@@ -62,11 +64,11 @@ export default class DummyContext implements Context {
     return true;
   }
 
-  async(span: Span) {
+  async(span: DummySpan) {
     ContextManager.clear(span);
   }
 
-  resync(span: Span) {
+  resync(span: DummySpan) {
     ContextManager.restore(span);
   }
 }

--- a/src/trace/context/SpanContext.ts
+++ b/src/trace/context/SpanContext.ts
@@ -27,6 +27,7 @@ import ExitSpan from '../../trace/span/ExitSpan';
 import LocalSpan from '../../trace/span/LocalSpan';
 import SegmentRef from './SegmentRef';
 import ContextManager from './ContextManager';
+import Tag from '../../Tag';
 import { Component } from '../../trace/Component';
 import { createLogger } from '../../logging';
 import { ContextCarrier } from './ContextCarrier';
@@ -173,8 +174,13 @@ export default class SpanContext implements Context {
       nSpans: this.nSpans,
     });
 
-    if (!this.nSpans++)
+    if (!this.nSpans++) {
       SpanContext.nActiveSegments += 1;
+      span.isCold = ContextManager.checkCold();
+
+      if (span.isCold)
+        span.tag(Tag.coldStart(), true);
+    }
 
     if (spans.indexOf(span) === -1)
       spans.push(span);

--- a/tests/plugins/axios/expected.data.yaml
+++ b/tests/plugins/axios/expected.data.yaml
@@ -53,6 +53,8 @@ segmentItems:
             peer: not null
             skipAnalysis: false
             tags:
+              - key: coldStart
+                value: 'true'
               - key: http.url
                 value: http://server:5000/axios
               - key: http.method
@@ -101,6 +103,8 @@ segmentItems:
             spanId: 0
             spanLayer: Http
             tags:
+              - key: coldStart
+                value: 'true'
               - key: http.url
                 value: http://localhost:5001/axios
               - key: http.method

--- a/tests/plugins/express/expected.data.yaml
+++ b/tests/plugins/express/expected.data.yaml
@@ -27,6 +27,8 @@ segmentItems:
             spanId: 0
             spanLayer: Http
             tags:
+              - key: coldStart
+                value: 'true'
               - key: http.url
                 value: http://server:5000/express
               - key: http.method
@@ -81,6 +83,8 @@ segmentItems:
             spanId: 0
             spanLayer: Http
             tags:
+              - key: coldStart
+                value: 'true'
               - key: http.url
                 value: http://localhost:5001/express
               - key: http.method

--- a/tests/plugins/http/expected.data.yaml
+++ b/tests/plugins/http/expected.data.yaml
@@ -33,6 +33,8 @@ segmentItems:
             peer: not null
             skipAnalysis: false
             tags:
+              - key: coldStart
+                value: 'true'
               - key: http.url
                 value: http://server:5000/test
               - key: http.method
@@ -87,6 +89,8 @@ segmentItems:
             peer: not null
             skipAnalysis: false
             tags:
+              - key: coldStart
+                value: 'true'
               - key: http.url
                 value: http://localhost:5001/test
               - key: http.method

--- a/tests/plugins/mongodb/expected.data.yaml
+++ b/tests/plugins/mongodb/expected.data.yaml
@@ -63,6 +63,7 @@ segmentItems:
             peer: not null
             skipAnalysis: false
             tags:
+              - { key: coldStart, value: 'true' }
               - { key: http.url, value: 'http://server:5000/mongo' }
               - { key: http.method, value: GET }
               - { key: http.status.code, value: '200' }
@@ -93,6 +94,7 @@ segmentItems:
             peer: not null
             skipAnalysis: false
             tags:
+              - { key: coldStart, value: 'true' }
               - { key: http.url, value: 'http://localhost:5001/mongo' }
               - { key: http.method, value: GET }
               - { key: http.status.code, value: '200' }

--- a/tests/plugins/mongoose/expected.data.yaml
+++ b/tests/plugins/mongoose/expected.data.yaml
@@ -77,6 +77,7 @@ segmentItems:
             peer: not null
             skipAnalysis: false
             tags:
+              - { key: coldStart, value: 'true' }
               - { key: http.url, value: 'http://server:5000/mongoose' }
               - { key: http.method, value: GET }
               - { key: http.status.code, value: '200' }
@@ -107,6 +108,7 @@ segmentItems:
             peer: not null
             skipAnalysis: false
             tags:
+              - { key: coldStart, value: 'true' }
               - { key: http.url, value: 'http://localhost:5001/mongoose' }
               - { key: http.method, value: GET }
               - { key: http.status.code, value: '200' }

--- a/tests/plugins/mysql/expected.data.yaml
+++ b/tests/plugins/mysql/expected.data.yaml
@@ -51,6 +51,8 @@ segmentItems:
             peer: not null
             skipAnalysis: false
             tags:
+              - key: coldStart
+                value: 'true'
               - key: http.url
                 value: http://server:5000/mysql
               - key: http.method
@@ -85,6 +87,8 @@ segmentItems:
             peer: not null
             skipAnalysis: false
             tags:
+              - key: coldStart
+                value: 'true'
               - key: http.url
                 value: http://localhost:5001/mysql
               - key: http.method

--- a/tests/plugins/pg/expected.data.yaml
+++ b/tests/plugins/pg/expected.data.yaml
@@ -48,6 +48,7 @@ segmentItems:
             peer: not null
             skipAnalysis: false
             tags:
+              - { key: coldStart, value: 'true' }
               - { key: http.url, value: 'http://server:5000/postgres' }
               - { key: http.method, value: GET }
               - { key: http.status.code, value: '200' }
@@ -78,6 +79,7 @@ segmentItems:
             peer: not null
             skipAnalysis: false
             tags:
+              - { key: coldStart, value: 'true' }
               - { key: http.url, value: 'http://localhost:5001/postgres' }
               - { key: http.method, value: GET }
               - { key: http.status.code, value: '200' }


### PR DESCRIPTION
I don't think I've seen this mechanism in the other agents but I was asked to implement this. A cold start is when an instance is spun up to serve a request, for this reason the response time of the endpoint includes the spinup time of the instance, which is not ideal. This PR detects this condition and marks spans to which it applies.

Cold start detection is as follows: First span to run within 1 second of skywalking init is considered a cold start. This span gets the tag 'coldStart' set to 'true'. This span also optionally gets the text '\<cold\>' appended to the endpoint name if env var SW_COLD_ENDPOINT is set to 'true' or config option 'coldEndpoint', the default is off (normal endpoint names). A dummy span running first due to ignore is considered a valid first run and eats the cold start. Note: 'coldStart' tag is not added at all if cold start is not detected, which means most spans will not have anything extra added.

The metrics of the endpoint that was cold-started do not change (much) so this tag is not for the endpoint itself but for analysis of spans upstream which will be significantly slower due to the cold start. The visual part via 'coldEndpoint' is more for quick visual analysis in the trace view.

The target environment for this was Azure Functions which we are working on now but the mechanism is general so it should apply in any environment where instances are spun up on demand (Kubernetes). Performance-wise it is just a flag check so impact should be nothing.