### PR TITLE
fix move husky dependency to normal deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,6 @@
     "express": "^4.17.1",
     "grpc-tools": "^1.11.1",
     "grpc_tools_node_protoc_ts": "^5.3.0",
-    "husky": "^7.0.4",
     "ioredis": "^4.27.2",
     "jest": "^26.6.3",
     "lint-staged": "^12.3.2",
@@ -78,6 +77,7 @@
   "dependencies": {
     "@grpc/grpc-js": "^1.4.4",
     "google-protobuf": "^3.14.0",
+    "husky": "^7.0.4",
     "semver": "^7.3.2",
     "tslib": "^2.0.3",
     "uuid": "^8.1.0",


### PR DESCRIPTION
Moved husky dependency from dev deps to normal deps, fails `npm install` from our scoped repository otherwise.