### PR TITLE
experimental AWS Lambda Function support

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -17,5 +17,8 @@ module.exports = {
   },
   env: {
     node: true
+  },
+  globals: {
+    "NodeJS": true
   }
 };

--- a/src/agent/protocol/Protocol.ts
+++ b/src/agent/protocol/Protocol.ts
@@ -26,4 +26,6 @@ export default interface Protocol {
   heartbeat(): this;
 
   report(): this;
+
+  flush(): Promise<any> | null;
 }

--- a/src/agent/protocol/grpc/GrpcProtocol.ts
+++ b/src/agent/protocol/grpc/GrpcProtocol.ts
@@ -43,4 +43,8 @@ export default class GrpcProtocol implements Protocol {
     this.traceReportClient.start();
     return this;
   }
+
+  flush(): Promise<any> | null {
+    return this.traceReportClient.flush();
+  }
 }

--- a/src/agent/protocol/grpc/clients/Client.ts
+++ b/src/agent/protocol/grpc/clients/Client.ts
@@ -21,4 +21,6 @@ export default interface Client {
   readonly isConnected: boolean;
 
   start(): void;
+
+  flush(): Promise<any> | null;
 }

--- a/src/agent/protocol/grpc/clients/HeartbeatClient.ts
+++ b/src/agent/protocol/grpc/clients/HeartbeatClient.ts
@@ -39,7 +39,7 @@ export default class HeartbeatClient implements Client {
   constructor() {
     this.managementServiceClient = new ManagementServiceClient(
       config.collectorAddress,
-      config.secure ? grpc.credentials.createSsl() : grpc.credentials.createInsecure()
+      config.secure ? grpc.credentials.createSsl() : grpc.credentials.createInsecure(),
     );
   }
 
@@ -58,38 +58,35 @@ export default class HeartbeatClient implements Client {
     }
 
     const keepAlivePkg = new InstancePingPkg()
-    .setService(config.serviceName)
-    .setServiceinstance(config.serviceInstance);
+      .setService(config.serviceName)
+      .setServiceinstance(config.serviceInstance);
 
     const instanceProperties = new InstanceProperties()
-    .setService(config.serviceName)
-    .setServiceinstance(config.serviceInstance)
-    .setPropertiesList([
-      new KeyStringValuePair().setKey('language').setValue('NodeJS'),
-      new KeyStringValuePair().setKey('OS Name').setValue(os.platform()),
-      new KeyStringValuePair().setValue('hostname').setValue(os.hostname()),
-      new KeyStringValuePair().setValue('Process No.').setValue(`${process.pid}`),
-    ]);
+      .setService(config.serviceName)
+      .setServiceinstance(config.serviceInstance)
+      .setPropertiesList([
+        new KeyStringValuePair().setKey('language').setValue('NodeJS'),
+        new KeyStringValuePair().setKey('OS Name').setValue(os.platform()),
+        new KeyStringValuePair().setValue('hostname').setValue(os.hostname()),
+        new KeyStringValuePair().setValue('Process No.').setValue(`${process.pid}`),
+      ]);
 
     this.heartbeatTimer = setInterval(() => {
-      this.managementServiceClient.reportInstanceProperties(
-        instanceProperties,
-        AuthInterceptor(),
-        (error, _) => {
-          if (error) {
-            logger.error('Failed to send heartbeat', error);
-          }
-        },
-      );
-      this.managementServiceClient.keepAlive(
-        keepAlivePkg,
-        AuthInterceptor(),
-        (error, _) => {
-          if (error) {
-            logger.error('Failed to send heartbeat', error);
-          }
-        },
-      );
+      this.managementServiceClient.reportInstanceProperties(instanceProperties, AuthInterceptor(), (error, _) => {
+        if (error) {
+          logger.error('Failed to send heartbeat', error);
+        }
+      });
+      this.managementServiceClient.keepAlive(keepAlivePkg, AuthInterceptor(), (error, _) => {
+        if (error) {
+          logger.error('Failed to send heartbeat', error);
+        }
+      });
     }, 20000).unref();
+  }
+
+  flush(): Promise<any> | null {
+    logger.warn('HeartbeatClient does not need flush().');
+    return null;
   }
 }

--- a/src/aws/AWSLambdaGatewayAPIHTTP.ts
+++ b/src/aws/AWSLambdaGatewayAPIHTTP.ts
@@ -1,0 +1,85 @@
+/*!
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import { URL } from 'url';
+import ContextManager from '../trace/context/ContextManager';
+import { Component } from '../trace/Component';
+import Tag from '../Tag';
+import { SpanLayer } from '../proto/language-agent/Tracing_pb';
+import { ContextCarrier } from '../trace/context/ContextCarrier';
+import Span from '../trace/span/Span';
+import DummySpan from '../trace/span/DummySpan';
+import { ignoreHttpMethodCheck } from '../config/AgentConfig';
+import { AWSLambdaTriggerPlugin } from './AWSLambdaTriggerPlugin';
+
+class AWSLambdaGatewayAPIHTTP extends AWSLambdaTriggerPlugin {
+  start(event: any, context: any): Span {
+    const headers = event.headers;
+    const reqCtx = event.requestContext;
+    const http = reqCtx?.http;
+    const method = http?.method;
+    const proto = http?.protocol ? http.protocol.split('/')[0].toLowerCase() : headers?.['x-forwarded-proto'];
+    const port = headers?.['x-forwarded-port'] || '';
+    const host = headers?.host ?? (reqCtx?.domainName || '');
+    const hostport = host ? (port ? `${host}:${port}` : host) : port;
+    const operation = http?.path ?? event.rawPath ?? (context.functionName ? `/${context.functionName}` : '/');
+
+    const query = event.rawQueryString
+      ? `?${event.rawQueryString}`
+      : event.queryStringParameters
+      ? '?' +
+        Object.entries(event.queryStringParameters)
+          .map(([k, v]) => `${k}=${v}`)
+          .join('&')
+      : '';
+
+    const carrier = headers && ContextCarrier.from(headers);
+
+    const span =
+      method && ignoreHttpMethodCheck(method)
+        ? DummySpan.create()
+        : ContextManager.current.newEntrySpan(operation, carrier);
+
+    span.layer = SpanLayer.HTTP;
+    span.component = Component.AWSLAMBDA_GATEWAYAPIHTTP;
+    span.peer = http?.sourceIp ?? headers?.['x-forwarded-for'] ?? 'Unknown';
+
+    if (method) span.tag(Tag.httpMethod(method));
+
+    if (hostport && proto) span.tag(Tag.httpURL(new URL(`${proto}://${hostport}${operation}${query}`).toString()));
+
+    span.start();
+
+    return span;
+  }
+
+  stop(span: Span, err: Error | null, res: any): void {
+    const statusCode = res?.statusCode || (typeof res === 'number' ? res : err ? 500 : null);
+
+    if (statusCode) {
+      if (statusCode >= 400) span.errored = true;
+
+      span.tag(Tag.httpStatusCode(statusCode));
+    }
+
+    span.stop();
+  }
+}
+
+export default new AWSLambdaGatewayAPIHTTP();

--- a/src/aws/AWSLambdaGatewayAPIREST.ts
+++ b/src/aws/AWSLambdaGatewayAPIREST.ts
@@ -1,0 +1,87 @@
+/*!
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import { URL } from 'url';
+import ContextManager from '../trace/context/ContextManager';
+import { Component } from '../trace/Component';
+import Tag from '../Tag';
+import { SpanLayer } from '../proto/language-agent/Tracing_pb';
+import { ContextCarrier } from '../trace/context/ContextCarrier';
+import Span from '../trace/span/Span';
+import DummySpan from '../trace/span/DummySpan';
+import { ignoreHttpMethodCheck } from '../config/AgentConfig';
+import { AWSLambdaTriggerPlugin } from './AWSLambdaTriggerPlugin';
+
+class AWSLambdaGatewayAPIREST extends AWSLambdaTriggerPlugin {
+  start(event: any, context: any): Span {
+    const headers = event.headers;
+    const reqCtx = event.requestContext;
+    const method = reqCtx?.httpMethod ?? event.httpMethod;
+    const proto = reqCtx?.protocol ? reqCtx.protocol.split('/')[0].toLowerCase() : headers?.['X-Forwarded-Proto'];
+    const port = headers?.['X-Forwarded-Port'] || '';
+    const host = headers?.Host ?? (reqCtx?.domainName || '');
+    const hostport = host ? (port ? `${host}:${port}` : host) : port;
+    const operation = reqCtx?.path ?? event.path ?? (context.functionName ? `/${context.functionName}` : '/');
+
+    const query = event.multiValueQueryStringParameters
+      ? '?' +
+        Object.entries(event.multiValueQueryStringParameters)
+          .map(([k, vs]: any[]) => vs.map((v: String) => `${k}=${v}`).join('&'))
+          .join('&')
+      : event.queryStringParameters
+      ? '?' +
+        Object.entries(event.queryStringParameters)
+          .map(([k, v]) => `${k}=${v}`)
+          .join('&')
+      : '';
+
+    const carrier = headers && ContextCarrier.from(headers);
+
+    const span =
+      method && ignoreHttpMethodCheck(method)
+        ? DummySpan.create()
+        : ContextManager.current.newEntrySpan(operation, carrier);
+
+    span.layer = SpanLayer.HTTP;
+    span.component = Component.AWSLAMBDA_GATEWAYAPIREST;
+    span.peer = reqCtx?.identity?.sourceIp ?? headers?.['X-Forwarded-For'] ?? 'Unknown';
+
+    if (method) span.tag(Tag.httpMethod(method));
+
+    if (hostport && proto) span.tag(Tag.httpURL(new URL(`${proto}://${hostport}${operation}${query}`).toString()));
+
+    span.start();
+
+    return span;
+  }
+
+  stop(span: Span, err: Error | null, res: any): void {
+    const statusCode = res?.statusCode || (typeof res === 'number' ? res : err ? 500 : null);
+
+    if (statusCode) {
+      if (statusCode >= 400) span.errored = true;
+
+      span.tag(Tag.httpStatusCode(statusCode));
+    }
+
+    span.stop();
+  }
+}
+
+export default new AWSLambdaGatewayAPIREST();

--- a/src/aws/AWSLambdaTriggerPlugin.ts
+++ b/src/aws/AWSLambdaTriggerPlugin.ts
@@ -1,0 +1,99 @@
+/*!
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import ContextManager from '../trace/context/ContextManager';
+import { Component } from '../trace/Component';
+import Span from '../trace/span/Span';
+import { default as agent } from '../index';
+
+class AWSLambdaTriggerPlugin {
+  // default working start function, should be overridden by the various types of lambda trigger subclasses
+  start(event: any, context: any): Span {
+    const span = ContextManager.current.newEntrySpan(context.functionName ? `/${context.functionName}` : '/');
+
+    span.component = Component.AWSLAMBDA_FUNCTION;
+    span.peer = 'Unknown';
+
+    span.start();
+
+    return span;
+  }
+
+  // default working stop function
+  stop(span: Span, err: Error | null, res: any): void {
+    span.stop();
+  }
+
+  wrap(func: any) {
+    return async (event: any, context: any, callback: any) => {
+      ContextManager.removeTailFinishedContexts(); // need this because AWS seems to chain sequential independent operations linearly instead of hierarchically
+
+      const span = this.start(event, context);
+      let ret: any;
+
+      let stop = async (err: Error | null, res: any) => {
+        stop = async (err: Error | null, res: any) => {};
+
+        this.stop(span, err, res);
+
+        const p = agent.flush(); // flush all data before aws freezes the process on exit
+
+        if (p) await p;
+
+        return res;
+      };
+
+      let resolve: any;
+      let reject: any;
+      let callbackDone = false;
+
+      const callbackPromise = new Promise((_resolve: any, _reject: any) => {
+        resolve = _resolve;
+        reject = _reject;
+      });
+
+      try {
+        ret = func(event, context, (err: Error | null, res: any) => {
+          if (!callbackDone) {
+            callbackDone = true;
+
+            if (err) reject(err);
+            else resolve(res);
+          }
+        });
+
+        if (typeof ret?.then !== 'function')
+          // generic Promise check
+          ret = callbackPromise;
+
+        return stop(null, await ret);
+      } catch (e) {
+        span.error(e);
+        stop(e, null);
+
+        throw e;
+      }
+    };
+  }
+}
+
+// noinspection JSUnusedGlobalSymbols
+export default new AWSLambdaTriggerPlugin();
+
+export { AWSLambdaTriggerPlugin };

--- a/src/trace/Component.ts
+++ b/src/trace/Component.ts
@@ -28,6 +28,9 @@ export class Component {
   static readonly RABBITMQ_PRODUCER = new Component(52);
   static readonly RABBITMQ_CONSUMER = new Component(53);
   static readonly AZURE_HTTPTRIGGER = new Component(111);
+  static readonly AWSLAMBDA_FUNCTION = new Component(124);
+  static readonly AWSLAMBDA_GATEWAYAPIHTTP = new Component(125);
+  static readonly AWSLAMBDA_GATEWAYAPIREST = new Component(126);
   static readonly EXPRESS = new Component(4002);
   static readonly AXIOS = new Component(4005);
   static readonly MONGOOSE = new Component(4006);


### PR DESCRIPTION
Explicit AWS Lambda Function plugins in their own `aws/` subdirectory. Manual wrapping of AWS handler functions is required (much like the Azure Functions plugin), see the README. The following have been added:

* `AWSLambdaTriggerPlugin` a generic wrapper which should work with all types of function triggers, but at the cost of information and linking back to calling endpoint.
* `AWSLambdaGatewayAPIHTTP` specific wrapper for GatewayAPI HTTP type triggers, stores HTTP info and status code and allows linking back to calling endpoint.
* `AWSLambdaGatewayAPIREST` same as above except for the GatewayAPI REST type trigger.
* `agent.flush()` mechanism for synchronizing on segment data send. This is needed for AWS Lambdas because AWS freezes processes in between invocations.
* `ContextManager.removeTailFinishedContexts()` to remove any finished spans from a context to break a parent-child chain which is invalid because sequential independent invocations of a handler are executed in inherited async contexts of previous runs instead of being executed hierarchically like most servers do (for AWS Lambda functions).

I will send up the component IDs to the main `skywalking` repo once tests are passed.
