### PR TITLE
add SW_AWSLAMBDA_FLUSH, fix husky again

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Environment Variable | Description | Default
 | `SW_SQL_PARAMETERS_MAX_LENGTH` | The maximum string length of SQL parameters to log | `512` |
 | `SW_MONGO_TRACE_PARAMETERS` | If set to 'true' then mongodb query parameters will be included | `false` |
 | `SW_MONGO_PARAMETERS_MAX_LENGTH` | The maximum string length of mongodb parameters to log | `512` |
+| `SW_AWSLAMBDA_FLUSH` | If set to 'true' then AWS Lambda functions will flush segment data when the handler finishes. `false` will be more optimal for high throughput applications but may lose spans. | `true` |
 | `SW_AGENT_MAX_BUFFER_SIZE` | The maximum buffer size before sending the segment data to backend | `'1000'` |
 
 Note that the various ignore options like `SW_IGNORE_SUFFIX`, `SW_TRACE_IGNORE_PATH` and `SW_HTTP_IGNORE_METHOD` as well as endpoints which are not recorded due to exceeding `SW_AGENT_MAX_BUFFER_SIZE` all propagate their ignored status downstream to any other endpoints they may call. If that endpoint is running the Node Skywalking agent then regardless of its ignore settings it will not be recorded since its upstream parent was not recorded. This allows elimination of entire trees of endpoints you are not interested in as well as eliminating partial traces if a span in the chain is ignored but calls out to other endpopints which are recorded as children of ROOT instead of the actual parent.

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
   "scripts": {
-    "postinstall": "husky install",
+    "postinstall": "node -e \"if(require('fs').existsSync('.git')){process.exit(1)}\" || husky install",
     "prepare": "npm run generate-source",
     "generate-source": "scripts/protoc.sh",
     "build": "npm run clean && npm run prepare && tsc --build src && OUT_DIR=lib/proto/ scripts/protoc.sh",

--- a/src/aws/AWSLambdaTriggerPlugin.ts
+++ b/src/aws/AWSLambdaTriggerPlugin.ts
@@ -17,6 +17,7 @@
  *
  */
 
+import config from '../config/AgentConfig';
 import ContextManager from '../trace/context/ContextManager';
 import { Component } from '../trace/Component';
 import Span from '../trace/span/Span';
@@ -52,9 +53,11 @@ class AWSLambdaTriggerPlugin {
 
         this.stop(span, err, res);
 
-        const p = agent.flush(); // flush all data before aws freezes the process on exit
+        if (config.awsLambdaFlush) {
+          const p = agent.flush(); // flush all data before aws freezes the process on exit
 
-        if (p) await p;
+          if (p) await p;
+        }
 
         return res;
       };

--- a/src/config/AgentConfig.ts
+++ b/src/config/AgentConfig.ts
@@ -35,6 +35,7 @@ export type AgentConfig = {
   sqlParametersMaxLength?: number;
   mongoTraceParameters?: boolean;
   mongoParametersMaxLength?: number;
+  awsLambdaFlush?: boolean;
   // the following is internal state computed from config values
   reDisablePlugins?: RegExp;
   reIgnoreOperation?: RegExp;
@@ -111,6 +112,7 @@ const _config = {
   sqlParametersMaxLength: Math.trunc(Math.max(0, Number(process.env.SW_SQL_PARAMETERS_MAX_LENGTH))) || 512,
   mongoTraceParameters: (process.env.SW_MONGO_TRACE_PARAMETERS || '').toLowerCase() === 'true',
   mongoParametersMaxLength: Math.trunc(Math.max(0, Number(process.env.SW_MONGO_PARAMETERS_MAX_LENGTH))) || 512,
+  awsLambdaFlush: (process.env.SW_AWSLAMBDA_FLUSH || '').toLowerCase() === 'true',
   reDisablePlugins: RegExp(''), // temporary placeholder so Typescript doesn't throw a fit
   reIgnoreOperation: RegExp(''),
   reHttpIgnoreMethod: RegExp(''),


### PR DESCRIPTION
Two things here:

* Added SW_AWSLAMBDA_FLUSH env var to explicitly enable / disable data flush on AWS Lambda function exit. This is meant for higher throughput functions where flushing after every call could be expensive. Turning off flush may lose spans but should be much more performant. Spans will simply be sent on subsequent invocations of the handler after the process wakes up.
* Fixed another problem with `husky`. Started getting the following error on clean install from scoped repo:
```
npm ERR! command sh -c husky install
npm ERR! .git can't be found (see https://git.io/Jc3F9)
```
Seems to be https://github.com/typicode/husky/issues/851 which is supposed to be fixed. Someone who understands this piece of software should double check that it is integrated correctly because this is the second problem encountered in just a couple of days.