### PR TITLE
fix awaits and SW_AWSLAMBDA_FLUSH default

### DIFF
--- a/src/aws/AWSLambdaTriggerPlugin.ts
+++ b/src/aws/AWSLambdaTriggerPlugin.ts
@@ -85,10 +85,10 @@ class AWSLambdaTriggerPlugin {
           // generic Promise check
           ret = callbackPromise;
 
-        return stop(null, await ret);
+        return await stop(null, await ret);
       } catch (e) {
         span.error(e);
-        stop(e, null);
+        await stop(e, null);
 
         throw e;
       }

--- a/src/aws/AWSLambdaTriggerPlugin.ts
+++ b/src/aws/AWSLambdaTriggerPlugin.ts
@@ -54,6 +54,8 @@ class AWSLambdaTriggerPlugin {
         this.stop(span, err, res);
 
         if (config.awsLambdaFlush) {
+          await new Promise((resolve) => setTimeout(resolve, 0)); // child spans of this span may have finalization waiting in the event loop in which case we give them a chance to run so that the segment can be archived properly for flushing
+
           const p = agent.flush(); // flush all data before aws freezes the process on exit
 
           if (p) await p;

--- a/src/config/AgentConfig.ts
+++ b/src/config/AgentConfig.ts
@@ -112,7 +112,7 @@ const _config = {
   sqlParametersMaxLength: Math.trunc(Math.max(0, Number(process.env.SW_SQL_PARAMETERS_MAX_LENGTH))) || 512,
   mongoTraceParameters: (process.env.SW_MONGO_TRACE_PARAMETERS || '').toLowerCase() === 'true',
   mongoParametersMaxLength: Math.trunc(Math.max(0, Number(process.env.SW_MONGO_PARAMETERS_MAX_LENGTH))) || 512,
-  awsLambdaFlush: (process.env.SW_AWSLAMBDA_FLUSH || '').toLowerCase() === 'true',
+  awsLambdaFlush: (process.env.SW_AWSLAMBDA_FLUSH || 'true').toLowerCase() === 'true',
   reDisablePlugins: RegExp(''), // temporary placeholder so Typescript doesn't throw a fit
   reIgnoreOperation: RegExp(''),
   reHttpIgnoreMethod: RegExp(''),


### PR DESCRIPTION
* Added awaits where they were missing before.
* Set correct default for SW_AWSLAMBDA_FLUSH.
* Let event loop tick once before flush in case child spans have finalizer waiting in the loop, if they don't proc then the segment is not archived and flushed.