### PR TITLE
Fix mysql2 plugin install error

### DIFF
--- a/src/core/OptionMethods.ts
+++ b/src/core/OptionMethods.ts
@@ -1,0 +1,24 @@
+/*!
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import PluginInstaller from './PluginInstaller';
+
+export default interface OptionMethods {
+  getVersion?(installer: PluginInstaller): string;
+}

--- a/src/core/PluginInstaller.ts
+++ b/src/core/PluginInstaller.ts
@@ -40,7 +40,7 @@ while (topModule.parent) {
 export default class PluginInstaller {
   private readonly pluginDir: string;
   readonly require: (name: string) => any = topModule.require.bind(topModule);
-  private readonly resolve = (request: string) => (module.constructor as any)._resolveFilename(request, topModule);
+  readonly resolve = (request: string) => (module.constructor as any)._resolveFilename(request, topModule);
 
   constructor() {
     this.pluginDir = path.resolve(__dirname, '..', 'plugins');
@@ -64,8 +64,13 @@ export default class PluginInstaller {
       };
     }
 
-    const packageJsonPath = this.resolve(`${plugin.module}/package.json`);
-    const version = this.require(packageJsonPath).version;
+    let version = null;
+    try {
+      const packageJsonPath = this.resolve(`${plugin.module}/package.json`);
+      version = this.require(packageJsonPath).version;
+    } catch (e) {
+      version = plugin.getVersion?.(this);
+    }
 
     if (!semver.satisfies(version, plugin.versions)) {
       logger.info(`Plugin ${plugin.module} ${version} doesn't satisfy the supported version ${plugin.versions}`);

--- a/src/core/SwPlugin.ts
+++ b/src/core/SwPlugin.ts
@@ -19,8 +19,9 @@
 
 import PluginInstaller from './PluginInstaller';
 import Span from '../trace/span/Span';
+import OptionMethods from './OptionMethods';
 
-export default interface SwPlugin {
+export default interface SwPlugin extends OptionMethods {
   readonly module: string;
   readonly versions: string;
 

--- a/src/plugins/MySQL2Plugin.ts
+++ b/src/plugins/MySQL2Plugin.ts
@@ -24,13 +24,22 @@ import Tag from '../Tag';
 import { SpanLayer } from '../proto/language-agent/Tracing_pb';
 import PluginInstaller from '../core/PluginInstaller';
 import agentConfig from '../config/AgentConfig';
+import * as fs from 'fs';
+import * as path from 'path';
 
 class MySQL2Plugin implements SwPlugin {
   readonly module = 'mysql2';
   readonly versions = '*';
 
+  getVersion(installer: PluginInstaller): string {
+    let indexPath = installer.resolve(this.module);
+    let packageSJonStr = fs.readFileSync(`${path.dirname(indexPath)}${path.sep}package.json`, { encoding: 'utf-8' });
+    const pkg = JSON.parse(packageSJonStr);
+    return pkg.version;
+  }
+
   install(installer: PluginInstaller): void {
-    const Connection = installer.require('mysql2/lib/connection');
+    const Connection = installer.require('mysql2').Connection;
     const _query = Connection.prototype.query;
 
     Connection.prototype.query = function (sql: any, values: any, cb: any) {


### PR DESCRIPTION
I've added an optional method to get the version information of the plugin. For most plugins it's not necessary to implement this method, the default `require('lib/package.json')` method can get its version, but the few libraries that specify `export` in `package.json` can't use default method. They must implement their own `getVersion()` method to get the version

Fix https://github.com/apache/skywalking/issues/7879