### PR TITLE
improved ignore path regex

### DIFF
--- a/src/config/AgentConfig.ts
+++ b/src/config/AgentConfig.ts
@@ -62,20 +62,27 @@ export function finalizeConfig(config: AgentConfig): void {
     config
       .traceIgnorePath!.split(',')
       .map(
-        (s1) =>
-          s1
+        (s0) =>
+          s0
             .trim()
-            .split('**')
+            .split('/**/')
             .map(
-              (s2) =>
-                s2
-                  .split('*')
+              (s1) =>
+                s1
+                  .trim()
+                  .split('**')
                   .map(
-                    (s3) => s3.split('?').map(escapeRegExp).join('[^/]'), // replaces "?"
+                    (s2) =>
+                      s2
+                        .split('*')
+                        .map(
+                          (s3) => s3.split('?').map(escapeRegExp).join('[^/]'), // replaces "?"
+                        )
+                        .join('[^/]*'), // replaces "*"
                   )
-                  .join('[^/]*'), // replaces "*"
+                  .join('(?:(?:[^/]+/)*[^/]+)?'), // replaces "**"
             )
-            .join('(?:(?:[^/]+/)*[^/]+)?'), // replaces "**"
+            .join('/(?:[^/]*/)*'), // replaces "/**/"
       )
       .join('|') +
     ')$'; // replaces ","


### PR DESCRIPTION
Minor enhancement/fix? Previously the config.traceIgnorePath pattern `/a/**/*` would match `/a/b/`, `/a/b/c` and `/a/b/c/`, etc... but not `/a/` or `/a/b`. Now it does.