### PR TITLE
Ignore no requests if ignoreSuffix is empty

### DIFF
--- a/src/config/AgentConfig.ts
+++ b/src/config/AgentConfig.ts
@@ -53,10 +53,19 @@ export function finalizeConfig(config: AgentConfig): void {
     'i',
   );
 
-  const ignoreSuffix = `^.+(?:${config
-    .ignoreSuffix!.split(',')
-    .map((s) => escapeRegExp(s.trim()))
-    .join('|')})$`;
+  const convertIgnoreSuffix = (configuredIgnoreSuffix: string | undefined) => {
+    if (!configuredIgnoreSuffix) {
+      // This regexp will never match => no files are ignored.
+      return '\\A(?!x)x';
+    } else {
+      return `^.+(?:${configuredIgnoreSuffix!
+        .split(',')
+        .map((s) => escapeRegExp(s.trim()))
+        .join('|')})$`;
+    }
+  };
+
+  const ignoreSuffix = convertIgnoreSuffix(config.ignoreSuffix);
   const ignorePath =
     '^(?:' +
     config


### PR DESCRIPTION
An empty ignore suffix currently causes all requests to be ignored. This makes it impossible to disable ignoring by suffix.

I could not find any test testing this regexp / other config stuff, so I did not write a test for my change.