### PR TITLE
Escape HTTP method in regexp

### DIFF
--- a/src/config/AgentConfig.ts
+++ b/src/config/AgentConfig.ts
@@ -91,7 +91,7 @@ export function finalizeConfig(config: AgentConfig): void {
   config.reHttpIgnoreMethod = RegExp(
     `^(?:${config
       .httpIgnoreMethod!.split(',')
-      .map((s) => s.trim())
+      .map((s) => escapeRegExp(s.trim()))
       .join('|')})$`,
     'i',
   );


### PR DESCRIPTION
In previous versions, the HTTP method was not escaped and could cause issues in regexp if special characters had been used.