### PR TITLE
fix: entry span url in endponts using Express middleware/router objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.5.2
+- Correct entry span url in endponts using Express middleware/router objects
+
 # 0.5.1
 - Fix `sw` header is not validated and might cause service unavailable. (#90)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,3 @@
-# 0.5.2
-- Correct entry span url in endponts using Express middleware/router objects
-
 # 0.5.1
 - Fix `sw` header is not validated and might cause service unavailable. (#90)
 

--- a/src/plugins/ExpressPlugin.ts
+++ b/src/plugins/ExpressPlugin.ts
@@ -43,7 +43,7 @@ class ExpressPlugin implements SwPlugin {
 
     router.handle = function (req: Request, res: ServerResponse, next: any) {
       const carrier = ContextCarrier.from((req as any).headers || {});
-      const operation = 'path:' + req.path + ';url:' + req.url + ';baseUrl:' + req.baseUrl + ";orig:" + req.originalUrl;
+      const operation = 'path:' + req.path + ';url:' + req.url + ';baseUrl:' + req.baseUrl + ';orig:' + req.originalUrl;
       const span = ignoreHttpMethodCheck(req.method ?? 'GET')
         ? DummySpan.create()
         : ContextManager.current.newEntrySpan(operation, carrier, [Component.HTTP_SERVER, Component.EXPRESS]);

--- a/src/plugins/ExpressPlugin.ts
+++ b/src/plugins/ExpressPlugin.ts
@@ -43,7 +43,7 @@ class ExpressPlugin implements SwPlugin {
 
     router.handle = function (req: Request, res: ServerResponse, next: any) {
       const carrier = ContextCarrier.from((req as any).headers || {});
-      const operation = (req.url || '/').replace(/\?.*/g, '');
+      const operation = 'path:' + req.path + ';url:' + req.url + ';baseUrl:' + req.baseUrl;
       const span = ignoreHttpMethodCheck(req.method ?? 'GET')
         ? DummySpan.create()
         : ContextManager.current.newEntrySpan(operation, carrier, [Component.HTTP_SERVER, Component.EXPRESS]);

--- a/src/plugins/ExpressPlugin.ts
+++ b/src/plugins/ExpressPlugin.ts
@@ -43,7 +43,7 @@ class ExpressPlugin implements SwPlugin {
 
     router.handle = function (req: Request, res: ServerResponse, next: any) {
       const carrier = ContextCarrier.from((req as any).headers || {});
-      const operation = 'path:' + req.path + ';url:' + req.url + ';baseUrl:' + req.baseUrl;
+      const operation = 'path:' + req.path + ';url:' + req.url + ';baseUrl:' + req.baseUrl + ";orig:" + req.originalUrl;
       const span = ignoreHttpMethodCheck(req.method ?? 'GET')
         ? DummySpan.create()
         : ContextManager.current.newEntrySpan(operation, carrier, [Component.HTTP_SERVER, Component.EXPRESS]);

--- a/src/plugins/ExpressPlugin.ts
+++ b/src/plugins/ExpressPlugin.ts
@@ -43,7 +43,7 @@ class ExpressPlugin implements SwPlugin {
 
     router.handle = function (req: Request, res: ServerResponse, next: any) {
       const carrier = ContextCarrier.from((req as any).headers || {});
-      const operation = 'path:' + req.path + ';url:' + req.url + ';baseUrl:' + req.baseUrl + ';orig:' + req.originalUrl;
+      const operation = (req.originalUrl || req.url || '/').replace(/\?.*/g, '');
       const span = ignoreHttpMethodCheck(req.method ?? 'GET')
         ? DummySpan.create()
         : ContextManager.current.newEntrySpan(operation, carrier, [Component.HTTP_SERVER, Component.EXPRESS]);

--- a/src/plugins/ExpressPlugin.ts
+++ b/src/plugins/ExpressPlugin.ts
@@ -27,6 +27,7 @@ import DummySpan from '../trace/span/DummySpan';
 import { ignoreHttpMethodCheck } from '../config/AgentConfig';
 import PluginInstaller from '../core/PluginInstaller';
 import HttpPlugin from './HttpPlugin';
+import { Request } from 'express';
 
 class ExpressPlugin implements SwPlugin {
   readonly module = 'express';
@@ -40,7 +41,7 @@ class ExpressPlugin implements SwPlugin {
     const router = installer.require('express/lib/router');
     const _handle = router.handle;
 
-    router.handle = function (req: IncomingMessage, res: ServerResponse, next: any) {
+    router.handle = function (req: Request, res: ServerResponse, next: any) {
       const carrier = ContextCarrier.from((req as any).headers || {});
       const operation = (req.url || '/').replace(/\?.*/g, '');
       const span = ignoreHttpMethodCheck(req.method ?? 'GET')

--- a/tests/plugins/express/client.ts
+++ b/tests/plugins/express/client.ts
@@ -28,7 +28,10 @@ agent.start({
 
 const app = express();
 
-app.get('/express', (req, res) => {
+const testRouter = express.Router();
+app.use('/test', testRouter);
+
+testRouter.get('/express', (req, res) => {
   http
   .request(`http://${process.env.SERVER || 'localhost:5000'}${req.url}`, (r) => {
     let data = '';

--- a/tests/plugins/express/expected.data.yaml
+++ b/tests/plugins/express/expected.data.yaml
@@ -86,7 +86,7 @@ segmentItems:
               - key: coldStart
                 value: 'true'
               - key: http.url
-                value: http://localhost:5001/express
+                value: http://localhost:5001/test/express
               - key: http.method
                 value: GET
               - key: http.status.code

--- a/tests/plugins/express/expected.data.yaml
+++ b/tests/plugins/express/expected.data.yaml
@@ -77,7 +77,7 @@ segmentItems:
     segments:
       - segmentId: not null
         spans:
-          - operationName: /express
+          - operationName: /test/express
             operationId: 0
             parentSpanId: -1
             spanId: 0

--- a/tests/plugins/express/test.ts
+++ b/tests/plugins/express/test.ts
@@ -39,7 +39,7 @@ describe('plugin tests', () => {
   });
 
   it(__filename, async () => {
-    await waitForExpect(async () => expect((await axios.get('http://localhost:5001/express')).status).toBe(200));
+    await waitForExpect(async () => expect((await axios.get('http://localhost:5001/test/express')).status).toBe(200));
 
     const expectedData = await fs.readFile(path.join(rootDir, 'expected.data.yaml'), 'utf8');
 


### PR DESCRIPTION
The following code:
```typescript
const app = express();
const testRouter = express.Router();

app.use('/test', testRouter);
testRouter.get('/express', (req, res) => {
    res.sendStatus(200);
});

app.listen(3000);
```

Results in entry spans with the URL of `/express` and not the correct URL of `/test/express`.

This PR solves that using [req.originalUrl](https://expressjs.com/en/4x/api.html#req.originalUrl) when available.