### PR TITLE
AWS DynamoDB, Lambda, SQS and SNS plugins, webpack

### DIFF
--- a/src/Tag.ts
+++ b/src/Tag.ts
@@ -25,7 +25,7 @@ export interface Tag {
 
 export default {
   coldStartKey: 'coldStart',
-  httpStatusCodeKey: 'http.status.code',  // TODO: maybe find a better place to put these?
+  httpStatusCodeKey: 'http.status.code', // TODO: maybe find a better place to put these?
   httpStatusMsgKey: 'http.status.msg',
   httpURLKey: 'http.url',
   httpMethodKey: 'http.method',
@@ -37,6 +37,7 @@ export default {
   mqBrokerKey: 'mq.broker',
   mqTopicKey: 'mq.topic',
   mqQueueKey: 'mq.queue',
+  arnKey: 'arn',
 
   coldStart(val: boolean = true): Tag {
     return {
@@ -125,6 +126,13 @@ export default {
   mqQueue(val: string | undefined): Tag {
     return {
       key: this.mqQueueKey,
+      overridable: true,
+      val: `${val}`,
+    } as Tag;
+  },
+  arn(val: string | undefined): Tag {
+    return {
+      key: this.arnKey,
       overridable: true,
       val: `${val}`,
     } as Tag;

--- a/src/agent/protocol/grpc/AuthInterceptor.ts
+++ b/src/agent/protocol/grpc/AuthInterceptor.ts
@@ -20,11 +20,10 @@
 import * as grpc from '@grpc/grpc-js';
 import config from '../../../config/AgentConfig';
 
-
-export default function AuthInterceptor() { 
-  const mata = new grpc.Metadata()
+export default function AuthInterceptor() {
+  const mata = new grpc.Metadata();
   if (config.authorization) {
     mata.add('Authentication', config.authorization);
-  }    
+  }
   return mata;
 }

--- a/src/agent/protocol/grpc/SegmentObjectAdapter.ts
+++ b/src/agent/protocol/grpc/SegmentObjectAdapter.ts
@@ -20,13 +20,7 @@
 import config from '../../../config/AgentConfig';
 import { KeyStringValuePair } from '../../../proto/common/Common_pb';
 import Segment from '../../../trace/context/Segment';
-import {
-  Log,
-  RefType,
-  SegmentObject,
-  SegmentReference,
-  SpanObject,
-} from '../../../proto/language-agent/Tracing_pb';
+import { Log, RefType, SegmentObject, SegmentReference, SpanObject } from '../../../proto/language-agent/Tracing_pb';
 
 /**
  * An adapter that adapts {@link Segment} objects to gRPC object {@link SegmentObject}.
@@ -35,55 +29,46 @@ export default class SegmentObjectAdapter extends SegmentObject {
   constructor(segment: Segment) {
     super();
     super
-    .setService(config.serviceName)
-    .setServiceinstance(config.serviceInstance)
-    .setTraceid(segment.relatedTraces[0].toString())
-    .setTracesegmentid(segment.segmentId.toString())
-    .setSpansList(
-      segment.spans.map((span) =>
-        new SpanObject()
-        .setSpanid(span.id)
-        .setParentspanid(span.parentId)
-        .setStarttime(span.startTime)
-        .setEndtime(span.endTime)
-        .setOperationname(span.operation)
-        .setPeer(span.peer)
-        .setSpantype(span.type)
-        .setSpanlayer(span.layer)
-        .setComponentid(span.component.id)
-        .setIserror(span.errored)
-        .setLogsList(
-          span.logs.map((log) =>
-            new Log()
-            .setTime(log.timestamp)
-            .setDataList(
-              log.items.map((logItem) =>
-                new KeyStringValuePair()
-                .setKey(logItem.key)
-                .setValue(logItem.val)),
+      .setService(config.serviceName)
+      .setServiceinstance(config.serviceInstance)
+      .setTraceid(segment.relatedTraces[0].toString())
+      .setTracesegmentid(segment.segmentId.toString())
+      .setSpansList(
+        segment.spans.map((span) =>
+          new SpanObject()
+            .setSpanid(span.id)
+            .setParentspanid(span.parentId)
+            .setStarttime(span.startTime)
+            .setEndtime(span.endTime)
+            .setOperationname(span.operation)
+            .setPeer(span.peer)
+            .setSpantype(span.type)
+            .setSpanlayer(span.layer)
+            .setComponentid(span.component.id)
+            .setIserror(span.errored)
+            .setLogsList(
+              span.logs.map((log) =>
+                new Log()
+                  .setTime(log.timestamp)
+                  .setDataList(
+                    log.items.map((logItem) => new KeyStringValuePair().setKey(logItem.key).setValue(logItem.val)),
+                  ),
+              ),
+            )
+            .setTagsList(span.tags.map((tag) => new KeyStringValuePair().setKey(tag.key).setValue(tag.val)))
+            .setRefsList(
+              span.refs.map((ref) =>
+                new SegmentReference()
+                  .setReftype(RefType.CROSSPROCESS)
+                  .setTraceid(ref.traceId.toString())
+                  .setParenttracesegmentid(ref.segmentId.toString())
+                  .setParentspanid(ref.spanId)
+                  .setParentservice(ref.service)
+                  .setParentserviceinstance(ref.serviceInstance)
+                  .setNetworkaddressusedatpeer(ref.clientAddress),
+              ),
             ),
-          ),
-        )
-        .setTagsList(
-          span.tags.map((tag) =>
-            new KeyStringValuePair()
-            .setKey(tag.key)
-            .setValue(tag.val),
-          ),
-        )
-        .setRefsList(
-          span.refs.map((ref) =>
-            new SegmentReference()
-            .setReftype(RefType.CROSSPROCESS)
-            .setTraceid(ref.traceId.toString())
-            .setParenttracesegmentid(ref.segmentId.toString())
-            .setParentspanid(ref.spanId)
-            .setParentservice(ref.service)
-            .setParentserviceinstance(ref.serviceInstance)
-            .setNetworkaddressusedatpeer(ref.clientAddress),
-          ),
         ),
-      ),
-    );
+      );
   }
 }

--- a/src/aws/AWSLambdaGatewayAPIHTTP.ts
+++ b/src/aws/AWSLambdaGatewayAPIHTTP.ts
@@ -29,7 +29,7 @@ import { ignoreHttpMethodCheck } from '../config/AgentConfig';
 import { AWSLambdaTriggerPlugin } from './AWSLambdaTriggerPlugin';
 
 class AWSLambdaGatewayAPIHTTP extends AWSLambdaTriggerPlugin {
-  start(event: any, context: any): Span {
+  start(event: any, context: any): [Span, any] {
     const headers = event.headers;
     const reqCtx = event.requestContext;
     const http = reqCtx?.http;
@@ -56,7 +56,6 @@ class AWSLambdaGatewayAPIHTTP extends AWSLambdaTriggerPlugin {
         ? DummySpan.create()
         : ContextManager.current.newEntrySpan(operation, carrier);
 
-    span.layer = SpanLayer.HTTP;
     span.component = Component.AWSLAMBDA_GATEWAYAPIHTTP;
     span.peer = http?.sourceIp ?? headers?.['x-forwarded-for'] ?? 'Unknown';
 
@@ -66,7 +65,7 @@ class AWSLambdaGatewayAPIHTTP extends AWSLambdaTriggerPlugin {
 
     span.start();
 
-    return span;
+    return [span, event];
   }
 
   stop(span: Span, err: Error | null, res: any): void {

--- a/src/aws/AWSLambdaGatewayAPIREST.ts
+++ b/src/aws/AWSLambdaGatewayAPIREST.ts
@@ -29,7 +29,7 @@ import { ignoreHttpMethodCheck } from '../config/AgentConfig';
 import { AWSLambdaTriggerPlugin } from './AWSLambdaTriggerPlugin';
 
 class AWSLambdaGatewayAPIREST extends AWSLambdaTriggerPlugin {
-  start(event: any, context: any): Span {
+  start(event: any, context: any): [Span, any] {
     const headers = event.headers;
     const reqCtx = event.requestContext;
     const method = reqCtx?.httpMethod ?? event.httpMethod;
@@ -58,7 +58,6 @@ class AWSLambdaGatewayAPIREST extends AWSLambdaTriggerPlugin {
         ? DummySpan.create()
         : ContextManager.current.newEntrySpan(operation, carrier);
 
-    span.layer = SpanLayer.HTTP;
     span.component = Component.AWSLAMBDA_GATEWAYAPIREST;
     span.peer = reqCtx?.identity?.sourceIp ?? headers?.['X-Forwarded-For'] ?? 'Unknown';
 
@@ -68,7 +67,7 @@ class AWSLambdaGatewayAPIREST extends AWSLambdaTriggerPlugin {
 
     span.start();
 
-    return span;
+    return [span, event];
   }
 
   stop(span: Span, err: Error | null, res: any): void {

--- a/src/aws/SDK2.ts
+++ b/src/aws/SDK2.ts
@@ -1,0 +1,230 @@
+/*!
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import Tag from '../Tag';
+import Span from '../trace/span/Span';
+import PluginInstaller from '../core/PluginInstaller';
+
+let _AWS: any = null;
+let _runTo: any, _send: any, _promise: any;
+
+// XXX: Special versions of wrapCallback() and wrapPromise() which allows wrapping successful callback. This is used
+// when an Exit span is converted to an Entry span on success of getting SQS messages. It does some extra stuff which is
+// harmless in this context because it comes from a specialized fork of agent.
+
+const wrapCallback = (span: Span, callback: any, idxError: any = false, state?: any) => {
+  return function (this: any, ...args: any[]) {
+    if (state) {
+      if (state.stopped)
+        // don't proc span stuff if span already stopped
+        return callback.apply(this, args);
+
+      if (!state.noStop) {
+        state.stopped = true;
+
+        if (state.timeouts) {
+          for (const timeout of state.timeouts) clearTimeout(timeout);
+        }
+      }
+    }
+
+    span.resync();
+
+    let ret;
+    let isErrorOrPostCall = idxError !== false && args[idxError];
+
+    try {
+      if (isErrorOrPostCall) span.error(args[idxError]);
+      else if (state?.beforeCB) {
+        isErrorOrPostCall = true;
+        span = state.beforeCB.call(this, span, ...args);
+        isErrorOrPostCall = false;
+
+        return callback.apply(this, args);
+      } else isErrorOrPostCall = true;
+    } catch (err) {
+      span.error(err);
+
+      throw err;
+    } finally {
+      if (!state?.noStop) span.stop();
+      else span.async();
+
+      if (isErrorOrPostCall) ret = callback.apply(this, args);
+    }
+
+    return ret;
+  };
+};
+
+const wrapPromise = (span: Span, promise: any, state?: any, initialized?: boolean) => {
+  if (!initialized) {
+    state = { ...(state || {}), stopped: 0, thend: 0, catched: 0, timeouts: [] };
+
+    promise = promise.then(
+      // make sure span ends even if there is no user .then(), .catch() or .finally()
+      (res: any) => {
+        state.timeouts.push(
+          setTimeout(() => {
+            if (!state.stopped++) {
+              span.stop();
+            }
+          }),
+        );
+
+        return res;
+      },
+
+      (err: any) => {
+        state.timeouts.push(
+          setTimeout(() => {
+            if (!state.stopped++) {
+              span.error(err);
+              span.stop();
+            }
+          }),
+        );
+
+        return Promise.reject(err);
+      },
+    );
+  }
+
+  const _then = promise.then;
+  const _catch = promise.catch;
+
+  Object.defineProperty(promise, 'then', {
+    configurable: true,
+    writable: true,
+    value: function (this: any, ...args: any[]): any {
+      if (args[0] && !state.thend++) args[0] = wrapCallback(span, args[0], false, state);
+      if (args[1] && !state.catched++) args[1] = wrapCallback(span, args[1], 0, state);
+
+      const _promise = _then.apply(this, args);
+
+      if (state.thend && state.catched) return _promise;
+      else return wrapPromise(span, _promise, state, true);
+    },
+  });
+
+  Object.defineProperty(promise, 'catch', {
+    configurable: true,
+    writable: true,
+    value: function (this: any, err: any): any {
+      if (!state.catched++) err = wrapCallback(span, err, 0, state);
+
+      const _promise = _catch.call(this, err);
+
+      if (state.thend && state.catched) return _promise;
+      else return wrapPromise(span, _promise, state, true);
+    },
+  });
+
+  return promise;
+};
+
+export function getAWS(installer: PluginInstaller): any {
+  if (!_AWS) {
+    _AWS = installer.require?.('aws-sdk') ?? require('aws-sdk');
+    _runTo = _AWS.Request.prototype.runTo;
+    _send = _AWS.Request.prototype.send;
+    _promise = _AWS.Request.prototype.promise;
+  }
+
+  return _AWS;
+}
+
+export const execute = (
+  span: Span,
+  _this: any,
+  func: any,
+  params: any,
+  callback: any,
+  hostTag?: string | null,
+  beforeCB?: (this: any, span: Span, ...args: any[]) => Span,
+) => {
+  span.start();
+  const state = beforeCB ? { beforeCB } : null;
+
+  try {
+    if (callback) callback = wrapCallback(span, callback, 0, state);
+
+    const req = func.call(_this, params, callback);
+
+    if (hostTag) span.tag((Tag[hostTag as keyof typeof Tag] as any)(req.httpRequest?.endpoint?.href));
+    else if (!span.peer && hostTag !== null) span.peer = req.httpRequest?.endpoint?.href;
+    // span.peer = `${req.httpRequest?.endpoint?.hostname ?? '???'}:${req.httpRequest?.endpoint?.port ?? '???'}`;
+
+    if (!callback) {
+      req.send = function (send_callback: any) {
+        if (send_callback) send_callback = callback = wrapCallback(span, send_callback, 0, state);
+
+        _send.call(this, send_callback);
+      };
+
+      req.promise = function () {
+        let ret = _promise.apply(this, arguments);
+
+        if (!callback) {
+          // we check just in case a .send() was done, which shouldn't be done but users...
+          callback = true;
+          ret = wrapPromise(
+            span,
+            ret,
+            // convert from Promise.then(res) success args to aws-sdk2 callback(err, res) success args
+            beforeCB ? { beforeCB: (span: Span, res: any) => beforeCB(span, null, res) } : null,
+          );
+        }
+
+        return ret;
+      };
+
+      req.on('complete', function (res: any) {
+        if (!callback) {
+          // we check again because .send() might have introduced a callback
+          const block = span.resync();
+
+          if (res.error) span.error(res.error);
+
+          span.stop();
+        }
+      });
+    }
+
+    req.runTo = function () {
+      // we need to resync for this so that the http client picks up our exit span and sees that it inherits from it and doesn't do a whole new span
+      span.resync();
+
+      try {
+        _runTo.apply(this, arguments);
+      } finally {
+        span.async();
+      }
+    };
+
+    span.async();
+
+    return req;
+  } catch (e) {
+    span.error(e);
+    span.stop();
+
+    throw e;
+  }
+};

--- a/src/config/AgentConfig.ts
+++ b/src/config/AgentConfig.ts
@@ -35,7 +35,9 @@ export type AgentConfig = {
   sqlParametersMaxLength?: number;
   mongoTraceParameters?: boolean;
   mongoParametersMaxLength?: number;
-  awsLambdaFlush?: boolean;
+  awsLambdaFlush?: number;
+  awsLambdaChain?: boolean;
+  awsSQSCheckBody?: boolean;
   // the following is internal state computed from config values
   reDisablePlugins?: RegExp;
   reIgnoreOperation?: RegExp;
@@ -128,7 +130,9 @@ const _config = {
   sqlParametersMaxLength: Math.trunc(Math.max(0, Number(process.env.SW_SQL_PARAMETERS_MAX_LENGTH))) || 512,
   mongoTraceParameters: (process.env.SW_MONGO_TRACE_PARAMETERS || '').toLowerCase() === 'true',
   mongoParametersMaxLength: Math.trunc(Math.max(0, Number(process.env.SW_MONGO_PARAMETERS_MAX_LENGTH))) || 512,
-  awsLambdaFlush: (process.env.SW_AWSLAMBDA_FLUSH || 'true').toLowerCase() === 'true',
+  awsLambdaFlush: ((n) => (Number.isNaN(n) ? -1 : n))(Number(process.env.SW_AWS_LAMBDA_FLUSH || 2)),
+  awsLambdaChain: (process.env.SW_AWS_LAMBDA_CHAIN || 'false').toLowerCase() === 'true',
+  awsSQSCheckBody: (process.env.SW_AWS_SQS_CHECK_BODY || 'false').toLowerCase() === 'true',
   reDisablePlugins: RegExp(''), // temporary placeholder so Typescript doesn't throw a fit
   reIgnoreOperation: RegExp(''),
   reHttpIgnoreMethod: RegExp(''),

--- a/src/config/AgentConfig.ts
+++ b/src/config/AgentConfig.ts
@@ -62,20 +62,27 @@ export function finalizeConfig(config: AgentConfig): void {
     config
       .traceIgnorePath!.split(',')
       .map(
-        (s1) =>
-          s1
+        (s0) =>
+          s0
             .trim()
-            .split('**')
+            .split('/**/')
             .map(
-              (s2) =>
-                s2
-                  .split('*')
+              (s1) =>
+                s1
+                  .trim()
+                  .split('**')
                   .map(
-                    (s3) => s3.split('?').map(escapeRegExp).join('[^/]'), // replaces "?"
+                    (s2) =>
+                      s2
+                        .split('*')
+                        .map(
+                          (s3) => s3.split('?').map(escapeRegExp).join('[^/]'), // replaces "?"
+                        )
+                        .join('[^/]*'), // replaces "*"
                   )
-                  .join('[^/]*'), // replaces "*"
+                  .join('(?:(?:[^/]+/)*[^/]+)?'), // replaces "**"
             )
-            .join('(?:(?:[^/]+/)*[^/]+)?'), // replaces "**"
+            .join('/(?:[^/]*/)*'), // replaces "/**/"
       )
       .join('|') +
     ')$'; // replaces ","

--- a/src/core/SwPlugin.ts
+++ b/src/core/SwPlugin.ts
@@ -24,6 +24,7 @@ import OptionMethods from './OptionMethods';
 export default interface SwPlugin extends OptionMethods {
   readonly module: string;
   readonly versions: string;
+  readonly isBuiltIn?: boolean;
 
   install(installer: PluginInstaller): void;
 }

--- a/src/plugins/AMQPLibPlugin.ts
+++ b/src/plugins/AMQPLibPlugin.ts
@@ -30,7 +30,7 @@ class AMQPLibPlugin implements SwPlugin {
   readonly versions = '*';
 
   install(installer: PluginInstaller): void {
-    const { BaseChannel } = installer.require('amqplib/lib/channel');
+    const { BaseChannel } = installer.require?.('amqplib/lib/channel') ?? require('amqplib/lib/channel');
 
     this.interceptProducer(BaseChannel);
     this.interceptConsumer(BaseChannel);

--- a/src/plugins/AWS2DynamoDBPlugin.ts
+++ b/src/plugins/AWS2DynamoDBPlugin.ts
@@ -1,0 +1,89 @@
+/*!
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import SwPlugin from '../core/SwPlugin';
+import ContextManager from '../trace/context/ContextManager';
+import { Component } from '../trace/Component';
+import Tag from '../Tag';
+import { SpanLayer } from '../proto/language-agent/Tracing_pb';
+import PluginInstaller from '../core/PluginInstaller';
+import { getAWS, execute } from '../aws/SDK2';
+
+class AWS2DynamoDBPlugin implements SwPlugin {
+  readonly module = 'aws-sdk';
+  readonly versions = '2.*';
+
+  install(installer: PluginInstaller): void {
+    const AWS = getAWS(installer);
+    const DocumentClient = AWS.DynamoDB.DocumentClient;
+
+    function instrument(name: string): void {
+      const _func = DocumentClient.prototype[name];
+
+      DocumentClient.prototype[name] = function (params: any, callback?: any): any {
+        const span = ContextManager.current.newExitSpan(`AWS/DynamoDB/${name}`, Component.POSTGRESQL, Component.HTTP);
+
+        span.component = Component.POSTGRESQL;
+        span.layer = SpanLayer.DATABASE;
+        // span.peer = `${this.service.endpoint.host ?? '<unknown>'}:${this.service.endpoint.port ?? '<unknown>'}`;
+
+        span.tag(Tag.dbType('DynamoDB'));
+        span.tag(Tag.dbStatement(name));
+
+        return execute(span, this, _func, params, callback);
+      };
+    }
+
+    instrument('batchGet');
+    instrument('batchWrite');
+    instrument('delete');
+    instrument('get');
+    instrument('put');
+    instrument('query');
+    instrument('scan');
+    instrument('update');
+    instrument('transactGet');
+    instrument('transactWrite');
+  }
+}
+
+// noinspection JSUnusedGlobalSymbols
+export default new AWS2DynamoDBPlugin();
+
+// // Example code for test maybe:
+// const AWS = require("aws-sdk");
+
+// AWS.config.update({region: 'your-region'});
+
+// const dynamo = new AWS.DynamoDB.DocumentClient();
+
+// function callback(err, data) {
+//     console.log('... callback err:', err);
+//     console.log('... callback data:', data);
+// }
+
+// const data = {TableName: "table-name", Item: {id: 1, name: 'Bob'}};
+
+// dynamo.put(data, callback);
+// // OR:
+// dynamo.put(data).send(callback);
+// // OR:
+// dynamo.put(data).promise()
+//   .then(r => { console.log('... promise res:', r); })
+//   .catch(e => { console.log('... promise err:', e); });

--- a/src/plugins/AWS2DynamoDBPlugin.ts
+++ b/src/plugins/AWS2DynamoDBPlugin.ts
@@ -37,9 +37,9 @@ class AWS2DynamoDBPlugin implements SwPlugin {
       const _func = DocumentClient.prototype[name];
 
       DocumentClient.prototype[name] = function (params: any, callback?: any): any {
-        const span = ContextManager.current.newExitSpan(`AWS/DynamoDB/${name}`, Component.POSTGRESQL, Component.HTTP);
+        const span = ContextManager.current.newExitSpan(`AWS/DynamoDB/${name}`, Component.AWS_DYNAMODB, Component.HTTP);
 
-        span.component = Component.POSTGRESQL;
+        span.component = Component.AWS_DYNAMODB;
         span.layer = SpanLayer.DATABASE;
         // span.peer = `${this.service.endpoint.host ?? '<unknown>'}:${this.service.endpoint.port ?? '<unknown>'}`;
 

--- a/src/plugins/AWS2LambdaPlugin.ts
+++ b/src/plugins/AWS2LambdaPlugin.ts
@@ -1,0 +1,128 @@
+/*!
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import { hostname } from 'os';
+import config from '../config/AgentConfig';
+import SwPlugin from '../core/SwPlugin';
+import ContextManager from '../trace/context/ContextManager';
+import { Component } from '../trace/Component';
+import Tag from '../Tag';
+import { SpanLayer } from '../proto/language-agent/Tracing_pb';
+import PluginInstaller from '../core/PluginInstaller';
+import { KeyTrace, KeyParams } from '../aws/AWSLambdaTriggerPlugin';
+import { getAWS, execute } from '../aws/SDK2';
+
+class AWS2LambdaPlugin implements SwPlugin {
+  readonly module = 'aws-sdk';
+  readonly versions = '2.*';
+
+  install(installer: PluginInstaller): void {
+    const AWS = getAWS(installer);
+    const _Lambda = AWS.Lambda;
+
+    function Lambda(this: any) {
+      const lambda = _Lambda.apply(this, arguments);
+      const _invoke = lambda.invoke;
+
+      lambda.invoke = function (params: any, callback: any) {
+        if (params.InvocationType === 'DryRun') return _invoke.call(this, params, callback);
+
+        let funcName = params.FunctionName;
+        const li = funcName.lastIndexOf(':');
+        let name;
+
+        if (li === -1) name = funcName;
+        else {
+          // my-function:v1
+          if (funcName.indexOf(':') === -1) name = funcName.slice(li);
+          else name = funcName.slice(li + 1); // 123456789012:function:my-function, arn:aws:lambda:us-west-2:123456789012:function:my-function
+        }
+
+        const span = ContextManager.current.newExitSpan(
+          `AWS/Lambda/invoke/${name || ''}`,
+          Component.AWSLAMBDA_FUNCTION,
+          Component.HTTP,
+        );
+
+        span.component = Component.AWSLAMBDA_FUNCTION;
+        span.layer = SpanLayer.HTTP;
+
+        if (li !== -1) span.tag(Tag.arn(funcName));
+
+        if (config.awsLambdaChain) {
+          let payload = params.Payload;
+
+          if (payload instanceof Buffer) payload = payload.toString();
+
+          if (typeof payload === 'string') {
+            const traceid = JSON.stringify(`${span.inject().value}/${hostname()}`);
+            const keyTrace = JSON.stringify(KeyTrace);
+            const keyParams = JSON.stringify(KeyParams);
+
+            if (payload.match(/^\s*{\s*}\s*$/)) payload = `{${keyTrace}:${traceid}}`;
+            else if (payload.match(/^\s*{/))
+              payload = `{${keyTrace}:${traceid},${payload.slice(payload.indexOf('{') + 1)}`;
+            else payload = `{${keyTrace}:${traceid},${keyParams}:${payload}}`;
+
+            params = Object.assign({}, params, { Payload: payload });
+          }
+        }
+
+        return execute(span, this, _invoke, params, callback);
+      };
+
+      return lambda;
+    }
+
+    Object.assign(Lambda, _Lambda);
+
+    Lambda.prototype = _Lambda.prototype;
+    AWS.Lambda = Lambda;
+  }
+}
+
+// noinspection JSUnusedGlobalSymbols
+export default new AWS2LambdaPlugin();
+
+// // Example code for test maybe:
+// const AWS = require("aws-sdk");
+
+// AWS.config.update({region: 'your-region'});
+
+// const lambda = new AWS.Lambda();
+
+// function callback(err, data) {
+//     console.log('... callback err:', err);
+//     console.log('... callback data:', data);
+// }
+
+// const params = {
+//   FunctionName: 'function_to_call',
+//   InvocationType: 'RequestResponse',  // or 'Event',
+//   // LogType: 'Tail',
+//   Payload: JSON.stringify({arg1: 'args to function'}),
+// };
+
+// lambda.invoke(params, callback);
+// // OR:
+// lambda.invoke(params).send(callback);
+// // OR:
+// lambda.invoke(params).promise()
+//   .then(r => { console.log('... promise res:', r); })
+//   .catch(e => { console.log('... promise err:', e); });

--- a/src/plugins/AWS2SNSPlugin.ts
+++ b/src/plugins/AWS2SNSPlugin.ts
@@ -50,10 +50,10 @@ class AWS2SNSPlugin implements SwPlugin {
             ? `Phone/${params.PhoneNumber}`
             : '???';
           const operation = `AWS/SNS/${name}/${to}`;
-          const span = ContextManager.current.newExitSpan(operation, Component.AWSLAMBDA_FUNCTION, Component.HTTP);
+          const span = ContextManager.current.newExitSpan(operation, Component.AWS_SNS, Component.HTTP);
           const arn = params.TopicArn || params.TargetArn;
 
-          span.component = Component.AWSLAMBDA_FUNCTION;
+          span.component = Component.AWS_SNS;
           span.layer = SpanLayer.MQ;
 
           if (arn) span.tag(Tag.arn(arn));

--- a/src/plugins/AWS2SNSPlugin.ts
+++ b/src/plugins/AWS2SNSPlugin.ts
@@ -1,0 +1,127 @@
+/*!
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import { hostname } from 'os';
+import SwPlugin from '../core/SwPlugin';
+import ContextManager from '../trace/context/ContextManager';
+import { Component } from '../trace/Component';
+import Tag from '../Tag';
+import Span from '../trace/span/Span';
+import { SpanLayer } from '../proto/language-agent/Tracing_pb';
+import PluginInstaller from '../core/PluginInstaller';
+import { getAWS, execute } from '../aws/SDK2';
+
+class AWS2SNSPlugin implements SwPlugin {
+  readonly module = 'aws-sdk';
+  readonly versions = '2.*';
+
+  install(installer: PluginInstaller): void {
+    const AWS = getAWS(installer);
+    const _SNS = AWS.SNS;
+
+    function SNS(this: any) {
+      const sns = _SNS.apply(this, arguments);
+
+      function instrument(name: string, addTraceId: any): void {
+        const _func = sns[name];
+
+        sns[name] = function (params: any, callback: any) {
+          const to = params.TopicArn
+            ? `Topic/${params.TopicArn.slice(params.TopicArn.lastIndexOf(':') + 1)}`
+            : params.TargetArn
+            ? `Target/${params.TargetArn.slice(params.TargetArn.lastIndexOf(':') + 1)}`
+            : params.PhoneNumber
+            ? `Phone/${params.PhoneNumber}`
+            : '???';
+          const operation = `AWS/SNS/${name}/${to}`;
+          const span = ContextManager.current.newExitSpan(operation, Component.AWSLAMBDA_FUNCTION, Component.HTTP);
+          const arn = params.TopicArn || params.TargetArn;
+
+          span.component = Component.AWSLAMBDA_FUNCTION;
+          span.layer = SpanLayer.MQ;
+
+          if (arn) span.tag(Tag.arn(arn));
+
+          if (params.TopicArn) params = addTraceId(params, span);
+
+          return execute(span, this, _func, params, callback, 'mqBroker');
+        };
+      }
+
+      instrument('publish', (params: any, span: Span) => {
+        params = Object.assign({}, params);
+        params.MessageAttributes = params.MessageAttributes ? Object.assign({}, params.MessageAttributes) : {};
+        params.MessageAttributes.__revdTraceId = {
+          DataType: 'String',
+          StringValue: `${span.inject().value}/${hostname()}`,
+        };
+
+        return params;
+      });
+
+      instrument('publishBatch', (params: any, span: Span) => {
+        const traceId = { __revdTraceId: { DataType: 'String', StringValue: `${span.inject().value}/${hostname()}` } };
+        params = Object.assign({}, params);
+        params.PublishBatchRequestEntries = params.PublishBatchRequestEntries.map(
+          (e: any) =>
+            (e = Object.assign({}, e, {
+              MessageAttributes: e.MessageAttributes ? Object.assign({}, e.MessageAttributes, traceId) : traceId,
+            })),
+        );
+
+        return params;
+      });
+
+      return sns;
+    }
+
+    Object.assign(SNS, _SNS);
+
+    SNS.prototype = _SNS.prototype;
+    AWS.SNS = SNS;
+  }
+}
+
+// noinspection JSUnusedGlobalSymbols
+export default new AWS2SNSPlugin();
+
+// // Example code for test maybe:
+// const AWS = require("aws-sdk");
+
+// AWS.config.update({region: 'your-region'});
+
+// const sns = new AWS.SNS();
+
+// function callback(err, data) {
+//     console.log('... callback err:', err);
+//     console.log('... callback data:', data);
+// }
+
+// const message = {
+//   Message: 'MESSAGE_TEXT', /* required */
+//   TopicArn: 'topic_arn',  /* or other destinations */
+// };
+
+// sns.publish(message, callback);
+// // OR:
+// sns.publish(message).send(callback);
+// // OR:
+// sns.publish(message).promise()
+//   .then(r => { console.log('... promise res:', r); })
+//   .catch(e => { console.log('... promise err:', e); });

--- a/src/plugins/AWS2SQSPlugin.ts
+++ b/src/plugins/AWS2SQSPlugin.ts
@@ -46,9 +46,9 @@ class AWS2SQSPlugin implements SwPlugin {
         sqs[name] = function (params: any, callback: any) {
           const queueUrl = params.QueueUrl;
           const operation = `AWS/SQS/${name}/${queueUrl.slice(queueUrl.lastIndexOf('/') + 1)}`;
-          const span = ContextManager.current.newExitSpan(operation, Component.AWSLAMBDA_FUNCTION, Component.HTTP);
+          const span = ContextManager.current.newExitSpan(operation, Component.AWS_SQS, Component.HTTP);
 
-          span.component = Component.AWSLAMBDA_FUNCTION;
+          span.component = Component.AWS_SQS;
           span.layer = SpanLayer.MQ;
 
           return execute(span, this, _func, addTraceId(params, span), callback, 'mqBroker');
@@ -92,13 +92,9 @@ class AWS2SQSPlugin implements SwPlugin {
 
         const queueUrl = params.QueueUrl;
         const operation = `AWS/SQS/receiveMessage/${queueUrl.slice(queueUrl.lastIndexOf('/') + 1)}`;
-        const span = ContextManager.current.newExitSpan(
-          `${operation}<check>`,
-          Component.AWSLAMBDA_FUNCTION,
-          Component.HTTP,
-        );
+        const span = ContextManager.current.newExitSpan(`${operation}<check>`, Component.AWS_SQS, Component.HTTP);
 
-        span.component = Component.AWSLAMBDA_FUNCTION;
+        span.component = Component.AWS_SQS;
         span.layer = SpanLayer.MQ;
 
         // should always be called on success only, with no err
@@ -152,7 +148,7 @@ class AWS2SQSPlugin implements SwPlugin {
 
             span = ContextManager.current.newEntrySpan(operation, carrier);
 
-            span.component = Component.AWSLAMBDA_FUNCTION;
+            span.component = Component.AWS_SQS;
             span.layer = SpanLayer.MQ;
             span.peer = peer;
 

--- a/src/plugins/AWS2SQSPlugin.ts
+++ b/src/plugins/AWS2SQSPlugin.ts
@@ -1,0 +1,218 @@
+/*!
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import { hostname } from 'os';
+import config from '../config/AgentConfig';
+import SwPlugin from '../core/SwPlugin';
+import { ContextCarrier } from '../trace/context/ContextCarrier';
+import ContextManager from '../trace/context/ContextManager';
+import { Component } from '../trace/Component';
+import Tag from '../Tag';
+import Span from '../trace/span/Span';
+import { SpanLayer } from '../proto/language-agent/Tracing_pb';
+import PluginInstaller from '../core/PluginInstaller';
+import { getAWS, execute } from '../aws/SDK2';
+
+class AWS2SQSPlugin implements SwPlugin {
+  readonly module = 'aws-sdk';
+  readonly versions = '2.*';
+
+  install(installer: PluginInstaller): void {
+    const AWS = getAWS(installer);
+    const _SQS = AWS.SQS;
+
+    function SQS(this: any) {
+      const sqs = _SQS.apply(this, arguments);
+
+      function instrumentSend(name: string, addTraceId: any): void {
+        const _func = sqs[name];
+
+        sqs[name] = function (params: any, callback: any) {
+          const queueUrl = params.QueueUrl;
+          const operation = `AWS/SQS/${name}/${queueUrl.slice(queueUrl.lastIndexOf('/') + 1)}`;
+          const span = ContextManager.current.newExitSpan(operation, Component.AWSLAMBDA_FUNCTION, Component.HTTP);
+
+          span.component = Component.AWSLAMBDA_FUNCTION;
+          span.layer = SpanLayer.MQ;
+
+          return execute(span, this, _func, addTraceId(params, span), callback, 'mqBroker');
+        };
+      }
+
+      instrumentSend('sendMessage', (params: any, span: Span) => {
+        params = Object.assign({}, params);
+        params.MessageAttributes = params.MessageAttributes ? Object.assign({}, params.MessageAttributes) : {};
+        params.MessageAttributes.__revdTraceId = {
+          DataType: 'String',
+          StringValue: `${span.inject().value}/${hostname()}`,
+        };
+
+        return params;
+      });
+
+      instrumentSend('sendMessageBatch', (params: any, span: Span) => {
+        const traceId = { __revdTraceId: { DataType: 'String', StringValue: `${span.inject().value}/${hostname()}` } };
+        params = Object.assign({}, params);
+        params.Entries = params.Entries.map(
+          (e: any) =>
+            (e = Object.assign({}, e, {
+              MessageAttributes: e.MessageAttributes ? Object.assign({}, e.MessageAttributes, traceId) : traceId,
+            })),
+        );
+
+        return params;
+      });
+
+      const _receiveMessage = sqs.receiveMessage;
+
+      sqs.receiveMessage = function (params: any, callback: any) {
+        params = Object.assign({}, params);
+        const _MessageAttributeNames = params.MessageAttributeNames;
+        params.MessageAttributeNames = _MessageAttributeNames
+          ? _MessageAttributeNames.concat(['__revdTraceId'])
+          : ['__revdTraceId'];
+
+        delete params.MaxNumberOfMessages; // limit to 1 message in order to be able to link all Exit and Entry spans
+
+        const queueUrl = params.QueueUrl;
+        const operation = `AWS/SQS/receiveMessage/${queueUrl.slice(queueUrl.lastIndexOf('/') + 1)}`;
+        const span = ContextManager.current.newExitSpan(
+          `${operation}<check>`,
+          Component.AWSLAMBDA_FUNCTION,
+          Component.HTTP,
+        );
+
+        span.component = Component.AWSLAMBDA_FUNCTION;
+        span.layer = SpanLayer.MQ;
+
+        // should always be called on success only, with no err
+        function beforeCB(this: any, span: Span, err: any, res: any): Span {
+          if (res.Messages?.length) {
+            const delall = !_MessageAttributeNames || !_MessageAttributeNames.length;
+            let traceId;
+
+            // should only be 1
+            for (let msg of res.Messages) {
+              if (msg.MessageAttributes !== undefined || !config.awsSQSCheckBody)
+                traceId = msg.MessageAttributes?.__revdTraceId?.StringValue;
+              else {
+                try {
+                  msg = JSON.parse(msg.Body);
+                  traceId = msg.MessageAttributes?.__revdTraceId?.Value;
+                } catch {
+                  // NOOP
+                }
+              }
+
+              if (traceId) {
+                if (delall) {
+                  delete msg.MD5OfMessageAttributes;
+                  delete msg.MessageAttributes;
+                } else {
+                  delete msg.MessageAttributes.__revdTraceId;
+
+                  if (!Object.keys(msg.MessageAttributes).length) {
+                    delete msg.MD5OfMessageAttributes;
+                    delete msg.MessageAttributes;
+                  }
+                }
+              }
+            }
+
+            let peer = 'Unknown';
+            let carrier: ContextCarrier | undefined = undefined;
+
+            if (traceId) {
+              const idx = traceId.lastIndexOf('/');
+
+              if (idx !== -1) {
+                peer = traceId.slice(idx + 1);
+                traceId = traceId.slice(0, idx);
+                carrier = ContextCarrier.from({ sw8: traceId });
+              }
+            }
+
+            span.stop();
+
+            span = ContextManager.current.newEntrySpan(operation, carrier);
+
+            span.component = Component.AWSLAMBDA_FUNCTION;
+            span.layer = SpanLayer.MQ;
+            span.peer = peer;
+
+            span.tag(Tag.mqBroker(queueUrl));
+
+            span.start();
+          }
+
+          return span;
+        }
+
+        return execute(span, this, _receiveMessage, params, callback, 'mqBroker', beforeCB);
+      };
+
+      return sqs;
+    }
+
+    Object.assign(SQS, _SQS);
+
+    SQS.prototype = _SQS.prototype;
+    AWS.SQS = SQS;
+  }
+}
+
+// noinspection JSUnusedGlobalSymbols
+export default new AWS2SQSPlugin();
+
+// // Example code for test maybe:
+// const AWS = require("aws-sdk");
+
+// AWS.config.update({region: 'your-region'});
+
+// const sqs = new AWS.SQS();
+
+// function callback(err, data) {
+//     console.log('... callback err:', err);
+//     console.log('... callback data:', data);
+// }
+
+// const send = {
+//   MessageBody: 'Hello World...', /* required */
+//   QueueUrl: 'https://queue_url', /* required */
+// };
+
+// sqs.sendMessage(send, callback);
+// // OR:
+// sqs.sendMessage(send).send(callback);
+// // OR:
+// sqs.sendMessage(send).promise()
+//   .then(r => { console.log('... promise res:', r); })
+//   .catch(e => { console.log('... promise err:', e); });
+
+// const recv = {
+//   QueueUrl: 'https://queue_url', /* required */
+// };
+
+// sqs.receiveMessage(recv, callback);
+// // OR:
+// sqs.receiveMessage(recv).send(callback);
+// // OR:
+// sqs.receiveMessage(recv).promise()
+//   .then(r => { console.log('... promise res:', r); })
+//   .catch(e => { console.log('... promise err:', e); });

--- a/src/plugins/AxiosPlugin.ts
+++ b/src/plugins/AxiosPlugin.ts
@@ -36,7 +36,7 @@ class AxiosPlugin implements SwPlugin {
   }
 
   private interceptClientRequest(installer: PluginInstaller): void {
-    const Axios = installer.require('axios/lib/core/Axios');
+    const Axios = installer.require?.('axios/lib/core/Axios') ?? require('axios/lib/core/Axios');
     const _request = Axios.prototype.request;
 
     Axios.prototype.request = function (url?: any, config?: any) {

--- a/src/plugins/ExpressPlugin.ts
+++ b/src/plugins/ExpressPlugin.ts
@@ -18,7 +18,7 @@
  */
 
 import SwPlugin from '../core/SwPlugin';
-import { IncomingMessage, ServerResponse } from 'http';
+import { ServerResponse } from 'http';
 import ContextManager from '../trace/context/ContextManager';
 import { Component } from '../trace/Component';
 import Tag from '../Tag';
@@ -38,7 +38,7 @@ class ExpressPlugin implements SwPlugin {
   }
 
   private interceptServerRequest(installer: PluginInstaller) {
-    const router = installer.require('express/lib/router');
+    const router = installer.require?.('express/lib/router') ?? require('express/lib/router');
     const _handle = router.handle;
 
     router.handle = function (req: Request, res: ServerResponse, next: any) {

--- a/src/plugins/ExpressPlugin.ts
+++ b/src/plugins/ExpressPlugin.ts
@@ -45,7 +45,7 @@ class ExpressPlugin implements SwPlugin {
       const operation = (req.url || '/').replace(/\?.*/g, '');
       const span = ignoreHttpMethodCheck(req.method ?? 'GET')
         ? DummySpan.create()
-        : ContextManager.current.newEntrySpan(operation, carrier, Component.HTTP_SERVER);
+        : ContextManager.current.newEntrySpan(operation, carrier, [Component.HTTP_SERVER, Component.EXPRESS]);
 
       span.component = Component.EXPRESS;
 

--- a/src/plugins/HttpPlugin.ts
+++ b/src/plugins/HttpPlugin.ts
@@ -32,6 +32,7 @@ import { ignoreHttpMethodCheck } from '../config/AgentConfig';
 class HttpPlugin implements SwPlugin {
   readonly module = 'http';
   readonly versions = '*';
+  readonly isBuiltIn = true;
 
   install(): void {
     const http = require('http');

--- a/src/plugins/IORedisPlugin.ts
+++ b/src/plugins/IORedisPlugin.ts
@@ -29,7 +29,7 @@ class IORedisPlugin implements SwPlugin {
   readonly versions = '*';
 
   install(installer: PluginInstaller): void {
-    const Redis = installer.require('ioredis');
+    const Redis = installer.require?.('ioredis') ?? require('ioredis');
 
     this.interceptOperation(Redis, 'sendCommand');
   }

--- a/src/plugins/MongoDBPlugin.ts
+++ b/src/plugins/MongoDBPlugin.ts
@@ -43,9 +43,9 @@ class MongoDBPlugin implements SwPlugin {
 
   install(installer: PluginInstaller): void {
     const plugin = this;
-    this.Collection = installer.require('mongodb/lib/collection');
-    this.Cursor = installer.require('mongodb/lib/cursor');
-    this.Db = installer.require('mongodb/lib/db');
+    this.Collection = installer.require?.('mongodb/lib/collection') ?? require('mongodb/lib/collection');
+    this.Cursor = installer.require?.('mongodb/lib/cursor') ?? require('mongodb/lib/cursor');
+    this.Db = installer.require?.('mongodb/lib/db') ?? require('mongodb/lib/db');
 
     const wrapCallbackWithCursorMaybe = (span: any, args: any[], idx: number): boolean => {
       const callback = args.length > idx && typeof args[(idx = args.length - 1)] === 'function' ? args[idx] : null;

--- a/src/plugins/MongoosePlugin.ts
+++ b/src/plugins/MongoosePlugin.ts
@@ -30,7 +30,7 @@ class MongoosePlugin implements SwPlugin {
   mongodbEnabled?: boolean;
 
   install(installer: PluginInstaller): void {
-    const { Model } = installer.require('mongoose');
+    const { Model } = installer.require?.('mongoose') ?? require('mongoose');
 
     this.interceptOperation(Model, 'aggregate');
     this.interceptOperation(Model, 'bulkWrite');

--- a/src/plugins/MySQL2Plugin.ts
+++ b/src/plugins/MySQL2Plugin.ts
@@ -32,14 +32,19 @@ class MySQL2Plugin implements SwPlugin {
   readonly versions = '*';
 
   getVersion(installer: PluginInstaller): string {
-    let indexPath = installer.resolve(this.module);
-    let packageSJonStr = fs.readFileSync(`${path.dirname(indexPath)}${path.sep}package.json`, { encoding: 'utf-8' });
-    const pkg = JSON.parse(packageSJonStr);
-    return pkg.version;
+    // TODO: this method will not work in a bundle
+    try {
+      let indexPath = installer.resolve(this.module);
+      let packageSJonStr = fs.readFileSync(`${path.dirname(indexPath)}${path.sep}package.json`, { encoding: 'utf-8' });
+      const pkg = JSON.parse(packageSJonStr);
+      return pkg.version;
+    } catch {
+      return '';
+    }
   }
 
   install(installer: PluginInstaller): void {
-    const Connection = installer.require('mysql2').Connection;
+    const Connection = (installer.require?.('mysql2') ?? require('mysql2')).Connection;
     const _query = Connection.prototype.query;
 
     Connection.prototype.query = function (sql: any, values: any, cb: any) {

--- a/src/plugins/MySQLPlugin.ts
+++ b/src/plugins/MySQLPlugin.ts
@@ -30,7 +30,7 @@ class MySQLPlugin implements SwPlugin {
   readonly versions = '*';
 
   install(installer: PluginInstaller): void {
-    const Connection = installer.require('mysql/lib/Connection');
+    const Connection = installer.require?.('mysql/lib/Connection') ?? require('mysql/lib/Connection');
     const _query = Connection.prototype.query;
 
     Connection.prototype.query = function (sql: any, values: any, cb: any) {

--- a/src/plugins/PgPlugin.ts
+++ b/src/plugins/PgPlugin.ts
@@ -30,12 +30,12 @@ class MySQLPlugin implements SwPlugin {
   readonly versions = '*';
 
   install(installer: PluginInstaller): void {
-    const Client = installer.require('pg/lib/client');
+    const Client = installer.require?.('pg/lib/client') ?? require('pg/lib/client');
 
     let Cursor: any;
 
     try {
-      Cursor = installer.require('pg-cursor');
+      Cursor = installer.require?.('pg-cursor') ?? require('pg-cursor');
     } catch {
       /* Linter food */
     }

--- a/src/trace/Component.ts
+++ b/src/trace/Component.ts
@@ -31,6 +31,9 @@ export class Component {
   static readonly AWSLAMBDA_FUNCTION = new Component(124);
   static readonly AWSLAMBDA_GATEWAYAPIHTTP = new Component(125);
   static readonly AWSLAMBDA_GATEWAYAPIREST = new Component(126);
+  static readonly AWS_DYNAMODB = new Component(138);
+  static readonly AWS_SNS = new Component(139);
+  static readonly AWS_SQS = new Component(140);
   static readonly EXPRESS = new Component(4002);
   static readonly AXIOS = new Component(4005);
   static readonly MONGOOSE = new Component(4006);

--- a/src/trace/context/Context.ts
+++ b/src/trace/context/Context.ts
@@ -32,7 +32,7 @@ export default interface Context {
   /* If 'inherit' is specified then if the span at the top of the stack is an Entry span of this component type then the
      span is reused instead of a new child span being created. This is intended for situations like an express handler
      inheriting an opened incoming http connection to present a single span. */
-  newEntrySpan(operation: string, carrier?: ContextCarrier, inherit?: Component): Span;
+  newEntrySpan(operation: string, carrier?: ContextCarrier, inherit?: Component | Component[]): Span;
 
   /* if 'inherit' is specified then the span returned is marked for inheritance by an Exit span component which is
      created later and calls this function with a matching 'component' value. For example Axios using an Http exit

--- a/src/trace/context/ContextManager.ts
+++ b/src/trace/context/ContextManager.ts
@@ -133,14 +133,12 @@ class ContextManager {
     if (spans.indexOf(span) === -1) spans.push(span);
   }
 
-  removeTailFinishedContexts(): void {
-    // XXX: Normally, SpanContexts that finish and send their segments can remain in the span lists of async contexts.
-    // This is so that if an async child that was spawned by the original span code and is executed after the parent
-    // finishes and creates its own span can be linked to the parent segment and span correctly. But in some situations
-    // where successive independent operations are chained linearly instead of hierarchically (AWS Lambda functions),
-    // this can cause a false reference by a subsequent operation as if it were a child of the finished previous span.
+  clearAll(): void {
+    // This is for situations where successive independent operations are chained linearly instead of hierarchically
+    // (AWS Lambda functions), this can cause a false reference by a subsequent operation as if it were a child of the
+    // previous span.
 
-    for (const spans = this.asyncState.spans; spans.length && spans[spans.length - 1].context.finished; spans.pop());
+    this.spansDup().splice(0);
   }
 
   withSpan(span: Span, callback: (...args: any[]) => any, ...args: any[]): any {

--- a/src/trace/context/DummyContext.ts
+++ b/src/trace/context/DummyContext.ts
@@ -30,7 +30,7 @@ export default class DummyContext implements Context {
   nSpans = 0;
   finished = false;
 
-  newEntrySpan(operation: string, carrier?: ContextCarrier, inherit?: Component): Span {
+  newEntrySpan(operation: string, carrier?: ContextCarrier, inherit?: Component | Component[]): Span {
     return DummySpan.create(this);
   }
 
@@ -46,18 +46,16 @@ export default class DummyContext implements Context {
     const spans = ContextManager.spansDup();
 
     if (!this.nSpans++) {
-      ContextManager.checkCold();  // set cold to false
+      ContextManager.checkCold(); // set cold to false
 
-      if (spans.indexOf(span) === -1)
-        spans.push(span);
+      if (spans.indexOf(span) === -1) spans.push(span);
     }
 
     return this;
   }
 
   stop(span: DummySpan): boolean {
-    if (--this.nSpans)
-      return false;
+    if (--this.nSpans) return false;
 
     ContextManager.clear(span);
 

--- a/src/trace/span/DummySpan.ts
+++ b/src/trace/span/DummySpan.ts
@@ -33,13 +33,11 @@ export default class DummySpan extends Span {
   }
 
   start(): any {
-    if (!this.depth++)
-      this.context.start(this);
+    if (!this.depth++) this.context.start(this);
   }
 
   stop(block?: any): void {
-    if (!--this.depth)
-      this.context.stop(this);
+    if (!--this.depth) this.context.stop(this);
   }
 
   async(block?: any): void {

--- a/src/trace/span/Span.ts
+++ b/src/trace/span/Span.ts
@@ -84,8 +84,7 @@ export default abstract class Span {
   }
 
   stop(): void {
-    if (--this.depth === 0)
-      this.context.stop(this);
+    if (--this.depth === 0) this.context.stop(this);
   }
 
   async(): void {
@@ -97,8 +96,7 @@ export default abstract class Span {
   }
 
   finish(segment: Segment): boolean {
-    if (this.isCold && config.coldEndpoint)
-      this.operation = this.operation + '<cold>';
+    if (this.isCold && config.coldEndpoint) this.operation = this.operation + '<cold>';
 
     this.endTime = new Date().getTime();
     segment.archive(this);
@@ -136,10 +134,8 @@ export default abstract class Span {
 
     const tagObj = Object.assign({}, tag);
 
-    if (!insert)
-      this.tags.push(tagObj);
-    else
-      this.tags.unshift(tagObj)
+    if (!insert) this.tags.push(tagObj);
+    else this.tags.unshift(tagObj);
 
     return this;
   }
@@ -147,14 +143,15 @@ export default abstract class Span {
   log(key: string, val: any): this {
     this.logs.push({
       timestamp: new Date().getTime(),
-      items: [{key, val: `${val}`}]
+      items: [{ key, val: `${val}` }],
     } as Log);
 
     return this;
   }
 
   error(error: Error): this {
-    if (error === this.lastError)  // don't store duplicate identical error twice
+    if (error === this.lastError)
+      // don't store duplicate identical error twice
       return this;
 
     this.errored = true;


### PR DESCRIPTION
The main things here are 4 new AWS SDK2 plugins and webpack support. The full list is:

* AWS SDK2 DynamoDB plugin.
* AWS SDK2 Lambda plugin.
* AWS SDK2 SQS plugin.
* AWS SDK2 SNS plugin.
* Instrument deprecated but possibly still used exit calls `done()`, `succeed()` and `fail()` from AWS Lambda function.
* Allow passing trace ID in AWS Lambda function parameters to allow linking outgoing to incoming calls.
* Extend AWS flush from boolean always/never to time threshold.
* Made agent.flush() wait on any unfinished Spans before waiting for protocol send to make sure all Spans in progress finish.
* Webpack support, can now run with most plugins from a bundle where before agent did not work at all from a bundle.
* Changed builtin plugin "detection" to explicit specification by plugin.
* Fix sequential invocation of Lambda function which does not flush and leaves an async component waiting to complete a Span incorrectly linking to a previous sibling Span.
* Fix double logging and undefined version print if plugin not supported.
* Fix Axios plugin to not return error but rather empty not supported version string if not supported (is deprecated anyway due to not compatible with Axios v1.0+, need to update).

The AWS plugins are in the `plugins/` directory and not the `aws/` directory because they are normal Node plugins which can be used on or off AWS to access those AWS services.