### PR TITLE
feat: add deadline for trace request

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ Environment Variable | Description | Default
 | `SW_AWS_LAMBDA_CHAIN` | Pass trace ID to AWS Lambda function in its parameters (to allow linking). Only use if both caller and callee will be instrumented. | `false` |
 | `SW_AWS_SQS_CHECK_BODY` | Incoming SQS messages check inside the body for trace ID in order to allow linking outgoing SNS messages to incoming SQS. | `false` |
 | `SW_AGENT_MAX_BUFFER_SIZE` | The maximum buffer size before sending the segment data to backend | `'1000'` |
+| `SW_AGENT_TRACE_TIMEOUT` | The timeout for trace requests to backend services | `'10000'` |
+
 
 Note that the various ignore options like `SW_IGNORE_SUFFIX`, `SW_TRACE_IGNORE_PATH` and `SW_HTTP_IGNORE_METHOD` as well as endpoints which are not recorded due to exceeding `SW_AGENT_MAX_BUFFER_SIZE` all propagate their ignored status downstream to any other endpoints they may call. If that endpoint is running the Node Skywalking agent then regardless of its ignore settings it will not be recorded since its upstream parent was not recorded. This allows the elimination of entire trees of endpoints you are not interested in as well as eliminating partial traces if a span in the chain is ignored but calls out to other endpoints which are recorded as children of ROOT instead of the actual parent.
 

--- a/src/agent/protocol/grpc/clients/TraceReportClient.ts
+++ b/src/agent/protocol/grpc/clients/TraceReportClient.ts
@@ -60,13 +60,17 @@ export default class TraceReportClient implements Client {
         return;
       }
 
-      const stream = this.reporterClient.collect(AuthInterceptor(), (error, _) => {
-        if (error) {
-          logger.error('Failed to report trace data', error);
-        }
+      const stream = this.reporterClient.collect(
+        AuthInterceptor(),
+        { deadline: Date.now() + config.traceTimeout },
+        (error, _) => {
+          if (error) {
+            logger.error('Failed to report trace data', error);
+          }
 
-        if (callback) callback();
-      });
+          if (callback) callback();
+        },
+      );
 
       try {
         for (const segment of this.buffer) {

--- a/src/config/AgentConfig.ts
+++ b/src/config/AgentConfig.ts
@@ -42,6 +42,7 @@ export type AgentConfig = {
   reDisablePlugins?: RegExp;
   reIgnoreOperation?: RegExp;
   reHttpIgnoreMethod?: RegExp;
+  traceTimeout?: number;
 };
 
 export function finalizeConfig(config: AgentConfig): void {
@@ -136,6 +137,9 @@ const _config = {
   reDisablePlugins: RegExp(''), // temporary placeholder so Typescript doesn't throw a fit
   reIgnoreOperation: RegExp(''),
   reHttpIgnoreMethod: RegExp(''),
+  traceTimeout: Number.isSafeInteger(process.env.SW_AGENT_TRACE_TIMEOUT)
+    ? Number.parseInt(process.env.SW_AGENT_TRACE_TIMEOUT as string, 10)
+    : 10 * 1000,
 };
 
 export default _config;


### PR DESCRIPTION
feat: add deadline for trace request

In our practice, we have found that when skywalking's backend service is under too much pressure to handle the request quickly, the trace request will stay alive by default and not be closed (the default value of grpc deadline is [2147483647](https://github.com/grpc/grpc-node/blob/master/packages/grpc-js/src/deadline.ts#L60C26-L60C36)). If the default `maxBufferSize` is used, a large number of requests per second will pile up, and slowly the client's memory will rise until it reaches the pod's limit and restarts. as shown:

<img width="1375" alt="截屏2023-09-03 下午9 47 09" src="https://github.com/apache/skywalking-nodejs/assets/3158736/5971e24e-50c4-4554-bc30-ef8a42bbc50d">

This also causes frequent up and down for skywalking's backend services (because of RetryingCall), which is very dangerous!

<img width="1037" alt="265268504-ed146317-35a2-4399-93bc-aaef7aebabc4" src="https://github.com/apache/skywalking-nodejs/assets/3158736/4cd3135f-34d6-400b-af97-225ba4d3c26a">




