### PR TITLE
fix tag name

### DIFF
--- a/src/Tag.ts
+++ b/src/Tag.ts
@@ -25,7 +25,7 @@ export interface Tag {
 
 export default {
   coldStartKey: 'coldStart',
-  httpStatusCodeKey: 'http.status.code', // TODO: maybe find a better place to put these?
+  httpStatusCodeKey: 'http.status_code', // TODO: maybe find a better place to put these?
   httpStatusMsgKey: 'http.status.msg',
   httpURLKey: 'http.url',
   httpMethodKey: 'http.method',

--- a/tests/plugins/axios/expected.data.yaml
+++ b/tests/plugins/axios/expected.data.yaml
@@ -37,7 +37,7 @@ segmentItems:
                 value: http://httpbin.org/json
               - key: http.method
                 value: GET
-              - key: http.status.code
+              - key: http.status_code
                 value: '200'
               - key: http.status.msg
                 value: OK
@@ -59,7 +59,7 @@ segmentItems:
                 value: http://server:5000/axios
               - key: http.method
                 value: GET
-              - key: http.status.code
+              - key: http.status_code
                 value: '200'
               - key: http.status.msg
                 value: OK
@@ -87,7 +87,7 @@ segmentItems:
                 value: http://server:5000/axios
               - key: http.method
                 value: GET
-              - key: http.status.code
+              - key: http.status_code
                 value: '200'
               - key: http.status.msg
                 value: OK
@@ -109,7 +109,7 @@ segmentItems:
                 value: http://localhost:5001/axios
               - key: http.method
                 value: GET
-              - key: http.status.code
+              - key: http.status_code
                 value: '200'
               - key: http.status.msg
                 value: OK

--- a/tests/plugins/express/expected.data.yaml
+++ b/tests/plugins/express/expected.data.yaml
@@ -33,7 +33,7 @@ segmentItems:
                 value: http://server:5000/express
               - key: http.method
                 value: GET
-              - key: http.status.code
+              - key: http.status_code
                 value: '200'
               - key: http.status.msg
                 value: OK
@@ -68,7 +68,7 @@ segmentItems:
                 value: http://httpbin.org/json
               - key: http.method
                 value: GET
-              - key: http.status.code
+              - key: http.status_code
                 value: '200'
               - key: http.status.msg
                 value: OK
@@ -89,7 +89,7 @@ segmentItems:
                 value: http://localhost:5001/test/express
               - key: http.method
                 value: GET
-              - key: http.status.code
+              - key: http.status_code
                 value: '200'
               - key: http.status.msg
                 value: OK
@@ -109,7 +109,7 @@ segmentItems:
                 value: http://server:5000/express
               - key: http.method
                 value: GET
-              - key: http.status.code
+              - key: http.status_code
                 value: '200'
               - key: http.status.msg
                 value: OK

--- a/tests/plugins/http/expected.data.yaml
+++ b/tests/plugins/http/expected.data.yaml
@@ -39,7 +39,7 @@ segmentItems:
                 value: http://server:5000/test
               - key: http.method
                 value: GET
-              - key: http.status.code
+              - key: http.status_code
                 value: '200'
               - key: http.status.msg
                 value: OK
@@ -68,7 +68,7 @@ segmentItems:
                 value: http://httpbin.org/json
               - key: http.method
                 value: GET
-              - key: http.status.code
+              - key: http.status_code
                 value: '200'
               - key: http.status.msg
                 value: OK
@@ -95,7 +95,7 @@ segmentItems:
                 value: http://localhost:5001/test
               - key: http.method
                 value: GET
-              - key: http.status.code
+              - key: http.status_code
                 value: '200'
               - key: http.status.msg
                 value: OK
@@ -115,7 +115,7 @@ segmentItems:
                 value: http://server:5000/test
               - key: http.method
                 value: GET
-              - key: http.status.code
+              - key: http.status_code
                 value: '200'
               - key: http.status.msg
                 value: OK

--- a/tests/plugins/ioredis/expected.data.yaml
+++ b/tests/plugins/ioredis/expected.data.yaml
@@ -80,7 +80,7 @@ segmentItems:
             tags:
               - { key: http.url, value: "http://server:5000/ioredis" }
               - { key: http.method, value: GET }
-              - { key: http.status.code, value: "200" }
+              - { key: http.status_code, value: "200" }
               - { key: http.status.msg, value: OK }
             refs:
               - parentEndpoint: ""
@@ -111,7 +111,7 @@ segmentItems:
               - { key: coldStart, value: "true" }
               - { key: http.url, value: "http://localhost:5001/ioredis" }
               - { key: http.method, value: GET }
-              - { key: http.status.code, value: "200" }
+              - { key: http.status_code, value: "200" }
               - { key: http.status.msg, value: OK }
           - operationName: /ioredis
             operationId: 0
@@ -127,5 +127,5 @@ segmentItems:
             tags:
               - { key: http.url, value: "http://server:5000/ioredis" }
               - { key: http.method, value: GET }
-              - { key: http.status.code, value: "200" }
+              - { key: http.status_code, value: "200" }
               - { key: http.status.msg, value: OK }

--- a/tests/plugins/mongodb/expected.data.yaml
+++ b/tests/plugins/mongodb/expected.data.yaml
@@ -66,7 +66,7 @@ segmentItems:
               - { key: coldStart, value: 'true' }
               - { key: http.url, value: 'http://server:5000/mongo' }
               - { key: http.method, value: GET }
-              - { key: http.status.code, value: '200' }
+              - { key: http.status_code, value: '200' }
               - { key: http.status.msg, value: OK }
             refs:
               - parentEndpoint: ""
@@ -97,7 +97,7 @@ segmentItems:
               - { key: coldStart, value: 'true' }
               - { key: http.url, value: 'http://localhost:5001/mongo' }
               - { key: http.method, value: GET }
-              - { key: http.status.code, value: '200' }
+              - { key: http.status_code, value: '200' }
               - { key: http.status.msg, value: OK }
           - operationName: /mongo
             operationId: 0
@@ -113,5 +113,5 @@ segmentItems:
             tags:
               - { key: http.url, value: 'http://server:5000/mongo' }
               - { key: http.method, value: GET }
-              - { key: http.status.code, value: '200' }
+              - { key: http.status_code, value: '200' }
               - { key: http.status.msg, value: OK }

--- a/tests/plugins/mongoose/expected.data.yaml
+++ b/tests/plugins/mongoose/expected.data.yaml
@@ -80,7 +80,7 @@ segmentItems:
               - { key: coldStart, value: 'true' }
               - { key: http.url, value: 'http://server:5000/mongoose' }
               - { key: http.method, value: GET }
-              - { key: http.status.code, value: '200' }
+              - { key: http.status_code, value: '200' }
               - { key: http.status.msg, value: OK }
             refs:
               - parentEndpoint: ""
@@ -111,7 +111,7 @@ segmentItems:
               - { key: coldStart, value: 'true' }
               - { key: http.url, value: 'http://localhost:5001/mongoose' }
               - { key: http.method, value: GET }
-              - { key: http.status.code, value: '200' }
+              - { key: http.status_code, value: '200' }
               - { key: http.status.msg, value: OK }
           - operationName: /mongoose
             operationId: 0
@@ -127,5 +127,5 @@ segmentItems:
             tags:
               - { key: http.url, value: 'http://server:5000/mongoose' }
               - { key: http.method, value: GET }
-              - { key: http.status.code, value: '200' }
+              - { key: http.status_code, value: '200' }
               - { key: http.status.msg, value: OK }

--- a/tests/plugins/mysql/expected.data.yaml
+++ b/tests/plugins/mysql/expected.data.yaml
@@ -57,7 +57,7 @@ segmentItems:
                 value: http://server:5000/mysql
               - key: http.method
                 value: GET
-              - key: http.status.code
+              - key: http.status_code
                 value: "200"
               - key: http.status.msg
                 value: OK
@@ -93,7 +93,7 @@ segmentItems:
                 value: http://localhost:5001/mysql
               - key: http.method
                 value: GET
-              - key: http.status.code
+              - key: http.status_code
                 value: "200"
               - key: http.status.msg
                 value: OK
@@ -113,7 +113,7 @@ segmentItems:
                 value: http://server:5000/mysql
               - key: http.method
                 value: GET
-              - key: http.status.code
+              - key: http.status_code
                 value: "200"
               - key: http.status.msg
                 value: OK

--- a/tests/plugins/mysql2/expected.data.yaml
+++ b/tests/plugins/mysql2/expected.data.yaml
@@ -57,7 +57,7 @@ segmentItems:
                 value: http://server:5000/mysql
               - key: http.method
                 value: GET
-              - key: http.status.code
+              - key: http.status_code
                 value: "200"
               - key: http.status.msg
                 value: OK
@@ -93,7 +93,7 @@ segmentItems:
                 value: http://localhost:5001/mysql
               - key: http.method
                 value: GET
-              - key: http.status.code
+              - key: http.status_code
                 value: "200"
               - key: http.status.msg
                 value: OK
@@ -113,7 +113,7 @@ segmentItems:
                 value: http://server:5000/mysql
               - key: http.method
                 value: GET
-              - key: http.status.code
+              - key: http.status_code
                 value: "200"
               - key: http.status.msg
                 value: OK

--- a/tests/plugins/pg/expected.data.yaml
+++ b/tests/plugins/pg/expected.data.yaml
@@ -51,7 +51,7 @@ segmentItems:
               - { key: coldStart, value: 'true' }
               - { key: http.url, value: 'http://server:5000/postgres' }
               - { key: http.method, value: GET }
-              - { key: http.status.code, value: '200' }
+              - { key: http.status_code, value: '200' }
               - { key: http.status.msg, value: OK }
             refs:
               - parentEndpoint: ""
@@ -82,7 +82,7 @@ segmentItems:
               - { key: coldStart, value: 'true' }
               - { key: http.url, value: 'http://localhost:5001/postgres' }
               - { key: http.method, value: GET }
-              - { key: http.status.code, value: '200' }
+              - { key: http.status_code, value: '200' }
               - { key: http.status.msg, value: OK }
           - operationName: /postgres
             operationId: 0
@@ -98,5 +98,5 @@ segmentItems:
             tags:
               - { key: http.url, value: 'http://server:5000/postgres' }
               - { key: http.method, value: GET }
-              - { key: http.status.code, value: '200' }
+              - { key: http.status_code, value: '200' }
               - { key: http.status.msg, value: OK }


### PR DESCRIPTION
Fix the OAL `httpResponseStatusCode` problems 
Because the `OAP` service uses `http.status_code` as analysis field, we need to fix it

https://github.com/apache/skywalking/blob/2603d2bd17a09723ebef0c5819f7c303b776f6d1/oap-server/analyzer/agent-analyzer/src/main/java/org/apache/skywalking/oap/server/analyzer/provider/trace/parser/listener/RPCAnalysisListener.java#L222