### PR TITLE
Fix: Ensure compatibility with Express 4.x and 5.x in ExpressPlugin

### DIFF
--- a/src/plugins/ExpressPlugin.ts
+++ b/src/plugins/ExpressPlugin.ts
@@ -1,3 +1,4 @@
+"use strict";
 /*!
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -16,85 +17,58 @@
  * limitations under the License.
  *
  */
-
-import SwPlugin from '../core/SwPlugin';
-import { ServerResponse } from 'http';
-import ContextManager from '../trace/context/ContextManager';
-import { Component } from '../trace/Component';
-import Tag from '../Tag';
-import { ContextCarrier } from '../trace/context/ContextCarrier';
-import DummySpan from '../trace/span/DummySpan';
-import { ignoreHttpMethodCheck } from '../config/AgentConfig';
-import PluginInstaller from '../core/PluginInstaller';
-import HttpPlugin from './HttpPlugin';
-import { Request } from 'express';
-
-class ExpressPlugin implements SwPlugin {
-  readonly module = 'express';
-  readonly versions = '*';
-
-  install(installer: PluginInstaller): void {
-    this.interceptServerRequest(installer);
-  }
-
-  private interceptServerRequest(installer: PluginInstaller) {
-    let router;
-
-    try {
-      // Express 4.x and older versions
-      router = installer.require?.('express/lib/router') ?? require('express/lib/router');
-    } catch (error) {
-      try {
-        // Express 5+ (uses dynamic import)
-        const express = require('express');
-        router = express.Router ? express.Router() : null;
-      } catch (err) {
-        console.error('⚠️ SkyWalking: Failed to load Express router - Express may not be installed.');
-        return;
-      }
+Object.defineProperty(exports, "__esModule", { value: true });
+var tslib_1 = require("tslib");
+var ContextManager_1 = tslib_1.__importDefault(require("../trace/context/ContextManager"));
+var Component_1 = require("../trace/Component");
+var Tag_1 = tslib_1.__importDefault(require("../Tag"));
+var ContextCarrier_1 = require("../trace/context/ContextCarrier");
+var DummySpan_1 = tslib_1.__importDefault(require("../trace/span/DummySpan"));
+var AgentConfig_1 = require("../config/AgentConfig");
+var HttpPlugin_1 = tslib_1.__importDefault(require("./HttpPlugin"));
+var ExpressPlugin = /** @class */ (function () {
+    function ExpressPlugin() {
+        this.module = 'express';
+        this.versions = '*';
     }
-
-    if (!router) {
-      console.warn('⚠️ SkyWalking: Unable to determine Express structure. Instrumentation is disabled.');
-      return;
-    }
-
-    const _handle = router.handle;
-
-    router.handle = function (req: Request, res: ServerResponse, next: any) {
-      const carrier = ContextCarrier.from((req as any).headers || {});
-      const reqMethod = req.method ?? 'GET';
-      const operation = reqMethod + ':' + (req.originalUrl || req.url || '/').replace(/\?.*/g, '');
-      const span = ignoreHttpMethodCheck(reqMethod)
-        ? DummySpan.create()
-        : ContextManager.current.newEntrySpan(operation, carrier, [Component.HTTP_SERVER, Component.EXPRESS]);
-
-      span.component = Component.EXPRESS;
-
-      if (span.depth) {
-        // If inherited from HTTP, just change the component ID and let HTTP handle it
-        return _handle.apply(this, arguments);
-      }
-
-      return HttpPlugin.wrapHttpResponse(span, req, res, () => {
-        // If HTTP plugin is disabled, we use this mechanism anyway
-        try {
-          return _handle.call(this, req, res, (err: Error) => {
-            span.error(err);
-            next.call(this, err);
-          });
-        } finally {
-          // req.protocol might only be available after calling _handle()
-          span.tag(
-            Tag.httpURL(
-              ((req as any).protocol ? (req as any).protocol + '://' : '') + (req.headers.host || '') + req.url,
-            ),
-          );
-        }
-      });
+    ExpressPlugin.prototype.install = function (installer) {
+        this.interceptServerRequest(installer);
     };
-  }
-}
-
+    ExpressPlugin.prototype.interceptServerRequest = function (installer) {
+        var _a, _b;
+        var express = require('express');
+        var router = express.Router ? express.Router() : require('express/lib/router');
+        var _handle = router.handle;
+        router.handle = function (req, res, next) {
+            var _this = this;
+            var _a;
+            var carrier = ContextCarrier_1.ContextCarrier.from(req.headers || {});
+            var reqMethod = (_a = req.method) !== null && _a !== void 0 ? _a : 'GET';
+            var operation = reqMethod + ':' + (req.originalUrl || req.url || '/').replace(/\?.*/g, '');
+            var span = AgentConfig_1.ignoreHttpMethodCheck(reqMethod)
+                ? DummySpan_1.default.create()
+                : ContextManager_1.default.current.newEntrySpan(operation, carrier, [Component_1.Component.HTTP_SERVER, Component_1.Component.EXPRESS]);
+            span.component = Component_1.Component.EXPRESS;
+            if (span.depth)
+                // if we inherited from http then just change component ID and let http do the work
+                return _handle.apply(this, arguments);
+            return HttpPlugin_1.default.wrapHttpResponse(span, req, res, function () {
+                // http plugin disabled, we use its mechanism anyway
+                try {
+                    return _handle.call(_this, req, res, function (err) {
+                        span.error(err);
+                        next.call(_this, err);
+                    });
+                }
+                finally {
+                    // req.protocol is only possibly available after call to _handle()
+                    span.tag(Tag_1.default.httpURL((req.protocol ? req.protocol + '://' : '') + (req.headers.host || '') + req.url));
+                }
+            });
+        };
+    };
+    return ExpressPlugin;
+}());
 // noinspection JSUnusedGlobalSymbols
-export default new ExpressPlugin();
+exports.default = new ExpressPlugin();
+//# sourceMappingURL=ExpressPlugin.js.map


### PR DESCRIPTION
We are evaluating the use of SkyWalking in our company, and I have started some proof-of-concept tests to evaluate the agents.  
I created a new project using Node.js/NestJS and the SkyWalking Node.js agent, following the instructions provided on the [NodeJS Agent page](https://github.com/thiagomatar/skywalking-nodejs) to install it in the project.

**Versions used:**  
- Node.js: 22.14.0  
- NestJS: 11.0.1  
- Express: 5.0.1  

Upon initializing the project, I encountered the following error message:  
```json
{
  message: 'Error installing plugin express *',
  level: 'error',
  file: '...node_modules/skywalking-backend-js/lib/core/PluginInstaller.js'
}
```

After investigating the code, I identified the root cause.  
In the [ExpressPlugin.js](https://github.com/apache/skywalking-nodejs/blob/master/src/plugins/ExpressPlugin.ts) file, line 39:  
```javascript
var router = (_b = (_a = installer.require) === null || _a === void 0 ? void 0 : _a.call(installer, 'express/lib/router')) !== null && _b !== void 0 ? _b : require('express/lib/router');
```

The error `Cannot find module 'express/lib/router'` occurs because the installed version of Express no longer has this folder structure (`express/lib/router`). This is due to recent versions of Express reorganizing their modules differently.

To address this issue, I am adding compatibility for both older and newer versions of Express:  
1. First, attempt to load `express.Router()` (used in Express 5+).  
2. If that fails, attempt to load `express/lib/router` (used in Express 4.x).  
