### PR TITLE
Fix: Express plugin compatibility for Express 4.x and 5.x

### DIFF
--- a/src/plugins/ExpressPlugin.ts
+++ b/src/plugins/ExpressPlugin.ts
@@ -38,7 +38,8 @@ class ExpressPlugin implements SwPlugin {
   }
 
   private interceptServerRequest(installer: PluginInstaller) {
-    const router = installer.require?.('express/lib/router') ?? require('express/lib/router');
+    var express = require('express');
+    var router = express.Router ? express.Router() : require('express/lib/router');
     const _handle = router.handle;
 
     router.handle = function (req: Request, res: ServerResponse, next: any) {

--- a/src/plugins/ExpressPlugin.ts
+++ b/src/plugins/ExpressPlugin.ts
@@ -38,8 +38,8 @@ class ExpressPlugin implements SwPlugin {
   }
 
   private interceptServerRequest(installer: PluginInstaller) {
-    var express = require('express');
-    var router = express.Router ? express.Router() : require('express/lib/router');
+    const express = installer.require?.('express') ?? require('express');
+    const router = express.Router ?? installer.require?.('express/lib/router') ?? require('express/lib/router');
     const _handle = router.handle;
 
     router.handle = function (req: Request, res: ServerResponse, next: any) {


### PR DESCRIPTION
We are evaluating the use of SkyWalking in our company, and I have started some proof-of-concept tests to evaluate the agents.  
I created a new project using Node.js/NestJS and the SkyWalking Node.js agent, following the instructions provided on the [NodeJS Agent page](https://github.com/thiagomatar/skywalking-nodejs) to install it in the project.

**Versions used:**  
- Node.js: 22.14.0  
- NestJS: 11.0.1  
- Express: 5.0.1  

Upon initializing the project, I encountered the following error message:  
```json
{
  message: 'Error installing plugin express *',
  level: 'error',
  file: '...node_modules/skywalking-backend-js/lib/core/PluginInstaller.js'
}
```

After investigating the code, I identified the root cause.  
In the [ExpressPlugin.js](https://github.com/apache/skywalking-nodejs/blob/master/src/plugins/ExpressPlugin.ts) file, line 39:  
```javascript
var router = (_b = (_a = installer.require) === null || _a === void 0 ? void 0 : _a.call(installer, 'express/lib/router')) !== null && _b !== void 0 ? _b : require('express/lib/router');
```

The error `Cannot find module 'express/lib/router'` occurs because the installed version of Express no longer has this folder structure (`express/lib/router`). This is due to recent versions of Express reorganizing their modules differently.

To address this issue, I am adding compatibility for both older and newer versions of Express:  
1. First, attempt to load `express.Router()` (used in Express 5+).  
2. If that fails, attempt to load `express/lib/router` (used in Express 4.x).  
