### PR TITLE
fix: add destroy methods to prevent memory leaks in protocol clients

### DIFF
--- a/src/agent/protocol/Protocol.ts
+++ b/src/agent/protocol/Protocol.ts
@@ -28,4 +28,6 @@ export default interface Protocol {
   report(): this;
 
   flush(): Promise<any> | null;
+
+  destroy?(): void;
 }

--- a/src/agent/protocol/grpc/GrpcProtocol.ts
+++ b/src/agent/protocol/grpc/GrpcProtocol.ts
@@ -47,4 +47,10 @@ export default class GrpcProtocol implements Protocol {
   flush(): Promise<any> | null {
     return this.traceReportClient.flush();
   }
+
+  destroy(): void {
+    // Clean up both clients to prevent memory leaks
+    this.heartbeatClient.destroy?.();
+    this.traceReportClient.destroy?.();
+  }
 }

--- a/src/agent/protocol/grpc/clients/Client.ts
+++ b/src/agent/protocol/grpc/clients/Client.ts
@@ -23,4 +23,6 @@ export default interface Client {
   start(): void;
 
   flush(): Promise<any> | null;
+
+  destroy?(): void;
 }

--- a/src/agent/protocol/grpc/clients/HeartbeatClient.ts
+++ b/src/agent/protocol/grpc/clients/HeartbeatClient.ts
@@ -89,4 +89,14 @@ export default class HeartbeatClient implements Client {
     logger.warn('HeartbeatClient does not need flush().');
     return null;
   }
+
+  destroy(): void {
+    // Clear heartbeat timer to prevent memory leak
+    if (this.heartbeatTimer) {
+      clearInterval(this.heartbeatTimer);
+      this.heartbeatTimer = undefined;
+    }
+
+    logger.info('HeartbeatClient destroyed and resources cleaned up');
+  }
 }

--- a/src/agent/protocol/grpc/clients/TraceReportClient.ts
+++ b/src/agent/protocol/grpc/clients/TraceReportClient.ts
@@ -34,16 +34,31 @@ export default class TraceReportClient implements Client {
   private readonly reporterClient: TraceSegmentReportServiceClient;
   private readonly buffer: Segment[] = [];
   private timeout?: NodeJS.Timeout;
+  private segmentFinishedListener: (segment: Segment) => void;
 
   constructor() {
     this.reporterClient = new TraceSegmentReportServiceClient(
       config.collectorAddress,
       config.secure ? grpc.credentials.createSsl() : grpc.credentials.createInsecure(),
     );
-    emitter.on('segment-finished', (segment) => {
+
+    // Store listener reference for cleanup
+    this.segmentFinishedListener = (segment: Segment) => {
+      // Limit buffer size to prevent memory leak during network issues
+      if (this.buffer.length >= config.maxBufferSize) {
+        logger.warn(
+          `Trace buffer reached maximum size (${config.maxBufferSize}). ` +
+          `Discarding oldest segment to prevent memory leak. ` +
+          `This may indicate network connectivity issues with the collector.`
+        );
+        this.buffer.shift(); // Remove oldest segment
+      }
+
       this.buffer.push(segment);
       this.timeout?.ref();
-    });
+    };
+
+    emitter.on('segment-finished', this.segmentFinishedListener);
   }
 
   get isConnected(): boolean {
@@ -106,5 +121,23 @@ export default class TraceReportClient implements Client {
       : new Promise((resolve) => {
           this.reportFunction(resolve);
         });
+  }
+
+  destroy(): void {
+    // Clean up event listener to prevent memory leak
+    if (this.segmentFinishedListener) {
+      emitter.off('segment-finished', this.segmentFinishedListener);
+    }
+
+    // Clear timeout
+    if (this.timeout) {
+      clearTimeout(this.timeout);
+      this.timeout = undefined;
+    }
+
+    // Clear buffer
+    this.buffer.length = 0;
+
+    logger.info('TraceReportClient destroyed and resources cleaned up');
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -72,6 +72,20 @@ class Agent {
       });
     });
   }
+
+  destroy(): void {
+    if (this.protocol === null) {
+      logger.warn('Trying to destroy() SkyWalking agent which is not started.');
+      return;
+    }
+
+    logger.info('Destroying SkyWalking agent and cleaning up resources');
+
+    // Clean up protocol resources
+    this.protocol.destroy?.();
+    this.protocol = null;
+    this.started = false;
+  }
 }
 
 export default new Agent();


### PR DESCRIPTION
In the event of prolonged network outages, this may lead to severe memory issues.

This pull request introduces a resource cleanup mechanism across the agent protocol and its gRPC client implementations to prevent memory leaks and ensure graceful shutdown. The main changes add a standardized optional `destroy()` method to key interfaces and classes, and implement cleanup logic for timers, event listeners, and buffers.

Resource cleanup and lifecycle management:

* Added an optional `destroy()` method to the `Protocol` and `Client` interfaces (`Protocol.ts`, `Client.ts`), and implemented it in `GrpcProtocol`, `HeartbeatClient`, and `TraceReportClient` to clean up resources such as timers, event listeners, and buffers. 

Memory leak prevention in gRPC clients:

* In `HeartbeatClient`, implemented `destroy()` to clear the heartbeat timer and log cleanup.
* In `TraceReportClient`, refactored event listener registration to store a reference for proper removal, and implemented `destroy()` to remove the event listener, clear timeouts and buffers, and log cleanup. Also added logic to limit buffer size and discard oldest segments with a warning to prevent memory leaks during network issues.

Agent shutdown support:

* Added a `destroy()` method to the `Agent` class to call the protocol's `destroy()` method, reset protocol state, and log the shutdown process.