### PR TITLE
Bugfix: collector unreachable causing system OOM

### DIFF
--- a/src/agent/protocol/grpc/clients/TraceReportClient.ts
+++ b/src/agent/protocol/grpc/clients/TraceReportClient.ts
@@ -48,8 +48,8 @@ export default class TraceReportClient implements Client {
       if (this.buffer.length >= config.maxBufferSize) {
         logger.warn(
           `Trace buffer reached maximum size (${config.maxBufferSize}). ` +
-          `Discarding oldest segment to prevent memory leak. ` +
-          `This may indicate network connectivity issues with the collector.`
+            `Discarding oldest segment to prevent memory leak. ` +
+            `This may indicate network connectivity issues with the collector.`,
         );
         this.buffer.shift(); // Remove oldest segment
       }
@@ -66,9 +66,30 @@ export default class TraceReportClient implements Client {
   }
 
   private reportFunction(callback?: any) {
-    emitter.emit('segments-sent'); // reset limiter in SpanContext
-
     try {
+      // Collector is unreachable. Do not call collect():
+      // gRPC would push the call onto its internal pickQueue and retain all
+      // SegmentObjectAdapter objects written via stream.write() until the
+      // deadline fires (default 10 s). With reportFunction running every 1 s,
+      // ~10 pending calls accumulate simultaneously, each holding up to
+      // maxBufferSize segment objects, causing unbounded heap growth → OOM.
+      //
+      // Do not emit 'segments-sent' either: withholding it keeps
+      // SpanContext.nActiveSegments above zero, so SpanContext returns
+      // DummyContext for new spans — natural backpressure that stops further
+      // segment production while the collector is down.
+      //
+      // isConnected calls getConnectivityState(true), which also triggers
+      // reconnection automatically when the channel is IDLE, so recovery
+      // is transparent once the collector comes back.
+      if (!this.isConnected) {
+        this.buffer.length = 0;
+        if (callback) callback();
+        return;
+      }
+
+      emitter.emit('segments-sent'); // reset limiter in SpanContext
+
       if (this.buffer.length === 0) {
         if (callback) callback();
 


### PR DESCRIPTION
## Summary

Fix a memory leak that causes OOM when the SkyWalking OAP collector is
persistently unreachable (e.g. `ECONNREFUSED` / `UNAVAILABLE`).

## Root Cause

`reportFunction` is scheduled every 1 s. On each tick, regardless of
connectivity, it:

1. Unconditionally emits `segments-sent` at the very top, resetting
   `SpanContext.nActiveSegments` to 0. This re-opens the gate for new
   segments immediately, even though nothing was delivered.

2. Calls `this.reporterClient.collect()` with a `deadline` of
   `now + traceTimeout` (default **10 000 ms**). When the channel is in
   `TRANSIENT_FAILURE`, gRPC-js accepts the call and pushes it onto its
   internal `pickQueue` (`internal-channel.js → queueCallForPick`).
   Every `stream.write()` keeps a `SegmentObjectAdapter` reference alive
   inside that queued call until the deadline expires.

3. Clears `this.buffer` — giving a false impression that memory is freed,
   while the actual data is still retained inside `pickQueue`.

With a 1 s interval and a 10 s deadline, **~10 calls accumulate
concurrently** in `pickQueue`. Each holds up to `maxBufferSize` (1 000)
segment objects. Because `segments-sent` is always emitted, new segments
keep flowing in without bound → **heap grows linearly → OOM**.

This is visible in V8 heap snapshots as a large count of `ConsOneByteString`
objects from the repeated `"Error: 14 UNAVAILABLE: No connection established"`
stack-trace string, retained by gRPC interceptor closure chains.

## Fix

Before creating any gRPC stream, check `this.isConnected` (which internally
calls `getConnectivityState(true)`).

**If not connected:**
- Skip `collect()` — no new call is pushed onto `pickQueue`.
- Skip `segments-sent` — `SpanContext.nActiveSegments` stays non-zero,
  so `SpanContext` returns `DummyContext` for new spans. This applies
  natural backpressure and stops further segment production during an outage.
- Clear `this.buffer` — releases any segments already queued at the
  application layer.
- `getConnectivityState(true)` also triggers `exitIdle()` when the channel
  is `IDLE`, so **reconnection is automatic** and tracing resumes within the
  next 1 s tick once the collector recovers.

**If connected (READY):** behaviour is identical to before.

## Behaviour Comparison

| Scenario | Before | After |
|---|---|---|
| Collector reachable | Normal | Normal (unchanged) |
| Collector unreachable | OOM over time | Memory stable, spans become no-ops |
| Collector recovers | N/A | Automatically resumes within ≤1 s |

## Testing

Start the agent pointing at an unreachable address, generate continuous
traffic, and observe `process.memoryUsage().heapUsed` over time.

**Before fix:** RSS grows ~50 MB/min at ~200 req/s.  
**After fix:** RSS remains stable; heap usage does not grow.

Once the collector address is restored, tracing resumes automatically
without restarting the process.