### PR TITLE
Release 0.9.0, bump to 0.10.0-dev

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "skywalking-backend-js",
-  "version": "0.9.0-dev",
+  "version": "0.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "skywalking-backend-js",
-      "version": "0.9.0-dev",
+      "version": "0.9.0",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -51,6 +51,9 @@
         "tsconfig-paths": "^3.9.0",
         "typescript": "^3.9.5",
         "wait-for-expect": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -7412,6 +7415,7 @@
       "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-5.13.13.tgz",
       "integrity": "sha512-M55tpCr/p5i6vdJ54nm4MG6/7SKV4JqlWnqbx6yCRuAuW05CZ7u+gNuHVPQVF9dZ59ALXjOtPEUl+OXklAa7ng==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@types/bson": "1.x || 4.0.x",
         "@types/mongodb": "^3.5.27",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "skywalking-backend-js",
-  "version": "0.9.0",
+  "version": "0.10.0-dev",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "skywalking-backend-js",
-      "version": "0.9.0",
+      "version": "0.10.0-dev",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "skywalking-backend-js",
-  "version": "0.9.0",
+  "version": "0.10.0-dev",
   "description": "The NodeJS agent for Apache SkyWalking",
   "homepage": "skywalking.apache.org",
   "main": "lib/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "skywalking-backend-js",
-  "version": "0.9.0-dev",
+  "version": "0.9.0",
   "description": "The NodeJS agent for Apache SkyWalking",
   "homepage": "skywalking.apache.org",
   "main": "lib/index.js",


### PR DESCRIPTION
Release branch for 0.9.0 — two commits: strip -dev (tagged v0.9.0, the RC the vote runs against) and bump to 0.10.0-dev. Merge AFTER the [VOTE] passes; the v0.9.0 tag stays pinned to the release commit.