### PR TITLE
chore: bump master to 0.10.0-dev (0.9.0 released)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "skywalking-backend-js",
-  "version": "0.9.0-dev",
+  "version": "0.10.0-dev",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "skywalking-backend-js",
-      "version": "0.9.0-dev",
+      "version": "0.10.0-dev",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "skywalking-backend-js",
-  "version": "0.9.0-dev",
+  "version": "0.10.0-dev",
   "description": "The NodeJS agent for Apache SkyWalking",
   "homepage": "skywalking.apache.org",
   "main": "lib/index.js",


### PR DESCRIPTION
Master is on `0.9.0-dev` but 0.9.0 is released, so it should be `0.10.0-dev`. The next-dev bump rode in the release PR #135, which was closed (it targeted a feature branch), so it never landed on master. This advances `package.json` + lockfile to `0.10.0-dev`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)