### PR TITLE
feat(nodejs): gRPC TLS/DNS failover, 12 runtime meters, Java agent.core alignment

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -91,6 +91,74 @@ jobs:
           npm i
           npm run test tests/plugins/${{ matrix.plugin }}/
 
+
+  TestRemoteE2E:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    needs: [ build-matrix ]
+    strategy:
+      matrix:
+        node-version: [ 20, 22, 24 ]
+        case: [ static-failover, dns-re-resolve ]
+    env:
+      SW_NODE_VERSION: ${{ matrix.node-version }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - uses: actions/cache@v4
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+
+      - name: Set Up NodeJS ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Pre-build E2E agent image
+        run: |
+          docker build -f tests/plugins/common/Dockerfile.agent \
+            --build-arg SW_NODE_VERSION=${{ matrix.node-version }} \
+            -t skywalking-nodejs-e2e-agent:${{ matrix.node-version }} .
+
+      - name: Remote E2E On Node@${{ matrix.node-version }} (${{ matrix.case }})
+        run: |
+          npm i
+          npm run test tests/remote-e2e/${{ matrix.case }}/
+
+
+  TestUnitRemote:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    strategy:
+      matrix:
+        node-version: [ 20, 22, 24 ]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - uses: actions/cache@v4
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+
+      - name: Set Up NodeJS ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Remote unit tests on Node@${{ matrix.node-version }}
+        run: |
+          npm i
+          npx jest tests/remote/ tests/config/ tests/core/ tests/runtime/ --runInBand
+
   TestLib:
     runs-on: ubuntu-latest
     timeout-minutes: 30

--- a/README.md
+++ b/README.md
@@ -55,7 +55,15 @@ Environment Variable | Description | Default
 | `SW_AGENT_NAME` | The name of the service | `your-nodejs-service` |
 | `SW_AGENT_INSTANCE` | The name of the service instance | Randomly generated |
 | `SW_AGENT_COLLECTOR_BACKEND_SERVICES` | The backend OAP server address | `127.0.0.1:11800` |
-| `SW_AGENT_SECURE` | Whether to use secure connection to backend OAP server | `false` |
+| `SW_AGENT_SECURE` | Whether to use secure connection to backend OAP server (deprecated; use `SW_AGENT_FORCE_TLS`) | `false` |
+| `SW_AGENT_IS_RESOLVE_DNS_PERIODICALLY` | Periodically re-resolve DNS for backend hostnames (Java `collector.is_resolve_dns_periodically`) | `false` |
+| `SW_AGENT_GRPC_CHANNEL_CHECK_INTERVAL` | gRPC channel health check interval in seconds (Java `collector.grpc_channel_check_interval`) | `30` |
+| `SW_AGENT_FORCE_RECONNECTION_PERIOD` | Force reconnection every N check intervals when backend is unavailable | `1` |
+| `SW_AGENT_COLLECTOR_HEARTBEAT_PERIOD` | Heartbeat period in seconds (Java `collector.heartbeat_period`) | `20` |
+| `SW_AGENT_FORCE_TLS` | Force TLS for gRPC channel even when no CA file is configured (uses system trust store) | `false` |
+| `SW_AGENT_SSL_TRUSTED_CA_PATH` | Trusted CA file path (relative to agent package root, or absolute). Default `ca/ca.crt` (Java `agent.ssl_trusted_ca_path`) | `ca/ca.crt` |
+| `SW_AGENT_SSL_CERT_CHAIN_PATH` | Client certificate chain for mTLS, relative to agent package root (requires `SW_AGENT_SSL_KEY_PATH`) | not set |
+| `SW_AGENT_SSL_KEY_PATH` | Client private key for mTLS (requires `SW_AGENT_SSL_CERT_CHAIN_PATH`) | not set |
 | `SW_AGENT_AUTHENTICATION` | The authentication token to verify that the agent is trusted by the backend OAP, as for how to configure the backend, refer to [the yaml](https://github.com/apache/skywalking/blob/4f0f39ffccdc9b41049903cc540b8904f7c9728e/oap-server/server-bootstrap/src/main/resources/application.yml#L155-L158). | not set |
 | `SW_AGENT_LOGGING_LEVEL` | The logging level, could be one of `error`, `warn`, `info`, `debug` | `info` |
 | `SW_AGENT_DISABLE_PLUGINS` | Comma-delimited list of plugins to disable in the plugins directory (e.g. "mysql", "express") | `` |
@@ -72,19 +80,32 @@ Environment Variable | Description | Default
 | `SW_AWS_SQS_CHECK_BODY` | Incoming SQS messages check inside the body for trace ID in order to allow linking outgoing SNS messages to incoming SQS. | `false` |
 | `SW_AGENT_MAX_BUFFER_SIZE` | The maximum buffer size before sending the segment data to backend | `'1000'` |
 | `SW_AGENT_TRACE_TIMEOUT` | The timeout for trace requests to backend services | `'10000'` |
-| `SW_AGENT_NODEJS_RUNTIME_METRICS_REPORTER_ACTIVE` | Whether to report Node.js runtime metrics through MeterReportService (default: collect 1s, report 1s) | `true` |
-| `SW_AGENT_NODEJS_RUNTIME_METRICS_COLLECT_PERIOD` | Runtime metric sample interval in milliseconds | `1000` |
-| `SW_AGENT_NODEJS_RUNTIME_METRICS_REPORT_PERIOD` | Runtime metric report interval in milliseconds (aligned with Java JVM metrics upload interval) | `1000` |
-| `SW_AGENT_NODEJS_RUNTIME_METRICS_BUFFER_SIZE` | Maximum buffered runtime metric samples before dropping oldest | `600` |
+| `SW_AGENT_RUNTIME_METRICS_REPORTER_ACTIVE` | Whether to report runtime metrics through MeterReportService (default: collect 1s, report 1s) | `true` |
+| `SW_AGENT_RUNTIME_METRICS_COLLECT_PERIOD` | Runtime metric sample interval in milliseconds | `1000` |
+| `SW_AGENT_RUNTIME_METRICS_REPORT_PERIOD` | Runtime metric report interval in milliseconds (aligned with Java JVM metrics upload interval) | `1000` |
+| `SW_AGENT_RUNTIME_METRICS_BUFFER_SIZE` | Maximum buffered runtime metric samples before dropping oldest | `600` |
+| `SW_AGENT_RUNTIME_METRICS_MAX_SNAPSHOTS_PER_REPORT` | Max runtime metric snapshots sent per report tick (limits stream burst on reconnect) | `1` |
+| `SW_AGENT_RUNTIME_METRICS_HEAP_SPACE_DETAIL` | When `false`, skip `v8.getHeapSpaceStatistics()` (old/new space meters report 0) | `true` |
+| `SW_AGENT_COLLECTOR_GRPC_UPSTREAM_TIMEOUT` | Upstream gRPC call deadline in seconds (Java `collector.grpc_upstream_timeout`; used by trace/meter/heartbeat). Falls back to `SW_AGENT_TRACE_TIMEOUT` when unset | `30` |
 
-Legacy env names `SW_AGENT_RUNTIME_METRICS_*`, `SW_AGENT_NVM_METRICS_*` and `SW_AGENT_NVM_JVM_*` are still accepted as deprecated aliases.
+Legacy env names `SW_AGENT_NODEJS_RUNTIME_METRICS_*`, `SW_AGENT_NVM_METRICS_*` and `SW_AGENT_NVM_JVM_*` are still accepted as deprecated aliases.
 
 
 Note that the various ignore options like `SW_IGNORE_SUFFIX`, `SW_TRACE_IGNORE_PATH` and `SW_HTTP_IGNORE_METHOD` as well as endpoints which are not recorded due to exceeding `SW_AGENT_MAX_BUFFER_SIZE` all propagate their ignored status downstream to any other endpoints they may call. If that endpoint is running the Node Skywalking agent then regardless of its ignore settings it will not be recorded since its upstream parent was not recorded. This allows the elimination of entire trees of endpoints you are not interested in as well as eliminating partial traces if a span in the chain is ignored but calls out to other endpoints which are recorded as children of ROOT instead of the actual parent.
 
+## Remote and gRPC Highlights
+
+Major additions aligned with the Java agent gRPC architecture:
+
+- **Remote layer** — BootService/ServiceManager orchestration, GRPCChannelManager with comma-separated backends and failover (`SW_AGENT_GRPC_CHANNEL_CHECK_INTERVAL`, `SW_AGENT_FORCE_RECONNECTION_PERIOD`).
+- **TLS / mTLS** — `SW_AGENT_FORCE_TLS` and `SW_AGENT_SSL_*`; per-hostname SNI when DNS resolves to Pod IPs (Kubernetes-friendly).
+- **DNS** — hostname expansion to A/AAAA records, optional periodic re-resolve (`SW_AGENT_IS_RESOLVE_DNS_PERIODICALLY`), IPv6 `[host]:port` targets.
+
+Operational constraints and tuning: [docs/nodejs-grpc-constraints.md](docs/nodejs-grpc-constraints.md).
+
 ## Node.js Runtime Metrics
 
-The agent reports six process-level meters (`instance_nodejs_*`) via `MeterReportService` by default (collect 1s, report 1s). Set `SW_AGENT_NODEJS_RUNTIME_METRICS_REPORTER_ACTIVE=false` to disable. Process CPU combines `process.cpuUsage()` user + system, normalized by logical CPU count (0–100%).
+The agent reports twelve process-level meters (`instance_nodejs_*`) via `MeterReportService` by default (collect 1s, report 1s). Set `SW_AGENT_RUNTIME_METRICS_REPORTER_ACTIVE=false` to disable. Process CPU combines `process.cpuUsage()` user + system, normalized by logical CPU count (0–100%).
 
 | Node.js source | Meter name | Notes |
 | :--- | :--- | :--- |
@@ -94,6 +115,12 @@ The agent reports six process-level meters (`instance_nodejs_*`) via `MeterRepor
 | `v8.getHeapStatistics().heap_size_limit` | `instance_nodejs_heap_limit` | bytes |
 | `process.memoryUsage().rss` | `instance_nodejs_rss` | bytes |
 | `process.memoryUsage().external` | `instance_nodejs_external_memory` | bytes |
+| `process.memoryUsage().arrayBuffers` | `instance_nodejs_array_buffers` | bytes |
+| `process.uptime()` | `instance_nodejs_uptime` | seconds |
+| `v8.getHeapStatistics().peak_malloced_memory` | `instance_nodejs_peak_malloced_memory` | bytes |
+| `v8.getHeapStatistics().number_of_detached_contexts` | `instance_nodejs_detached_contexts` | — |
+| `v8.getHeapSpaceStatistics()` old_space | `instance_nodejs_old_space_used` | bytes (0 when `SW_AGENT_RUNTIME_METRICS_HEAP_SPACE_DETAIL=false`) |
+| `v8.getHeapSpaceStatistics()` new_space | `instance_nodejs_new_space_used` | bytes (0 when `SW_AGENT_RUNTIME_METRICS_HEAP_SPACE_DETAIL=false`) |
 
 Custom business metrics are not available through a public API; use [OpenTelemetry metrics](https://skywalking.apache.org/docs/main/latest/en/setup/backend/opentelemetry-receiver/) if you need those.
 

--- a/docs/nodejs-grpc-constraints.md
+++ b/docs/nodejs-grpc-constraints.md
@@ -1,0 +1,25 @@
+# Node.js Agent — gRPC / TLS Operational Constraints
+
+The gRPC-related remote layer is modeled on the **mature Java agent gRPC architecture** in `apm-sniffer/apm-agent-core` (channel lifecycle, TLS/mTLS, trace and meter reporting, command handling). Configuration names and outward behavior target **Java parity** wherever grpc-js permits; remaining Node-specific gaps are listed below.
+
+Operational constraints for Node.js behaviors that differ from Java (or need grpc-js-specific rules). Env var names and defaults: [README](../README.md#set-up-nodejs-agent).
+
+---
+
+## TLS and collector address
+
+### Background
+
+When TLS is enabled and DNS resolves a hostname to Pod IPs, grpc-js connects to **`10.x.x.x:11800`** but the OAP certificate is issued for **`skywalking-oap.example.svc`**. The agent sets grpc-js **`grpc.ssl_target_name_override`** using **`BackendTarget.tlsServerName`** from DNS expansion (one SNI per configured hostname entry).
+
+### Behavior
+
+| Deployment | `SW_AGENT_COLLECTOR_BACKEND_SERVICES` |
+| :--- | :--- |
+| Kubernetes Headless Service | Single DNS name, e.g. `skywalking-oap.skywalking.svc:11800` |
+| Multiple OAP clusters (different certs) | Comma-separated hostnames — each gets its own SNI when resolved |
+| Static IP failover | Comma-separated **`IP:port`** only |
+
+If two hostnames resolve to the **same** IP with **different** SNI names during DNS expansion, the agent logs a warning and keeps the **first** hostname's SNI for that target.
+
+**Code reference:** `expandBackendAddresses`, `BackendTarget.tlsServerName`, `TLSChannelBuilder`.

--- a/src/agent/core/boot/AgentPackagePath.ts
+++ b/src/agent/core/boot/AgentPackagePath.ts
@@ -1,0 +1,78 @@
+/*!
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import path from 'path';
+
+let cachedPackagePath: string | undefined;
+
+/**
+ * Directory containing the agent npm package (Java {@code AgentPackagePath} parity).
+ * Resolved from {@code src|lib}/agent/core/boot/AgentPackagePath.ts.
+ */
+export function getAgentPackagePath(): string {
+  if (!cachedPackagePath) {
+    cachedPackagePath = path.resolve(__dirname, '..', '..', '..', '..');
+  }
+  return cachedPackagePath;
+}
+
+export function isPathInsideAgentRoot(resolvedPath: string): boolean {
+  return isPathInsideRoot(resolvedPath, getAgentPackagePath());
+}
+
+function isPathInsideRoot(resolvedPath: string, root: string): boolean {
+  const normalizedRoot = path.resolve(root);
+  const normalizedResolved = path.resolve(resolvedPath);
+  return normalizedResolved === normalizedRoot || normalizedResolved.startsWith(`${normalizedRoot}${path.sep}`);
+}
+
+/**
+ * Resolve TLS file paths relative to the agent package when not absolute
+ * (Java {@code new File(AgentPackagePath.getPath(), configuredPath)}).
+ */
+let absoluteTlsPathWarned = false;
+
+export function warnOnceAbsoluteTlsPath(configuredPath: string | undefined): void {
+  if (absoluteTlsPathWarned || !configuredPath || !path.isAbsolute(configuredPath.trim())) {
+    return;
+  }
+  absoluteTlsPathWarned = true;
+  console.warn('[skywalking] Absolute TLS path bypasses agent-package containment checks:', configuredPath.trim());
+}
+
+export function resolveAgentPath(configuredPath: string | undefined): string | undefined {
+  if (!configuredPath) {
+    return undefined;
+  }
+  if (path.isAbsolute(configuredPath)) {
+    warnOnceAbsoluteTlsPath(configuredPath);
+    return path.normalize(configuredPath);
+  }
+  const root = getAgentPackagePath();
+  const resolved = path.normalize(path.join(root, configuredPath));
+  if (!isPathInsideRoot(resolved, root)) {
+    throw new Error(`TLS path escapes agent package root: ${configuredPath}`);
+  }
+  return resolved;
+}
+
+/** @internal test hook */
+export function resetAgentPackagePathCacheForTest(): void {
+  cachedPackagePath = undefined;
+}

--- a/src/agent/core/boot/ServiceManager.ts
+++ b/src/agent/core/boot/ServiceManager.ts
@@ -24,6 +24,8 @@ import MeterSender from '../meter/MeterSender';
 import GRPCChannelManager from '../remote/GRPCChannelManager';
 import ServiceManagementClient from '../remote/ServiceManagementClient';
 import TraceSegmentServiceClient from '../remote/TraceSegmentServiceClient';
+import CommandService from '../commands/CommandService';
+import CommandExecutorService from '../commands/CommandExecutorService';
 
 const logger = createLogger(__filename);
 
@@ -39,6 +41,15 @@ class ServiceManager {
     return ServiceManager.instance;
   }
 
+  /** Java {@code ServiceManager#isBooted()}. */
+  isBooted(): boolean {
+    return this.booted;
+  }
+
+  /**
+   * Java {@code ServiceManager#boot()}: per-service try/catch, always marks booted at end.
+   * Instrumentation is installed before boot; failures are logged only (no rollback).
+   */
   boot(): void {
     if (this.booted) {
       return;
@@ -51,7 +62,7 @@ class ServiceManager {
       try {
         service.prepare();
       } catch (error) {
-        logger.error('ServiceManager prepare failed: %s', error);
+        logger.error('ServiceManager prepare failed for %s: %s', service.constructor.name, error);
       }
     }
 
@@ -59,7 +70,7 @@ class ServiceManager {
       try {
         service.boot();
       } catch (error) {
-        logger.error('ServiceManager boot failed: %s', error);
+        logger.error('ServiceManager boot failed for %s: %s', service.constructor.name, error);
       }
     }
 
@@ -67,7 +78,7 @@ class ServiceManager {
       try {
         service.onComplete();
       } catch (error) {
-        logger.error('ServiceManager onComplete failed: %s', error);
+        logger.error('ServiceManager onComplete failed for %s: %s', service.constructor.name, error);
       }
     }
 
@@ -113,6 +124,8 @@ class ServiceManager {
   }
 
   private loadServices(): void {
+    this.register(CommandExecutorService, new CommandExecutorService());
+    this.register(CommandService, new CommandService());
     this.register(GRPCChannelManager, new GRPCChannelManager());
     this.register(TraceSegmentServiceClient, new TraceSegmentServiceClient());
     this.register(ServiceManagementClient, new ServiceManagementClient());

--- a/src/agent/core/commands/CommandExecutorService.ts
+++ b/src/agent/core/commands/CommandExecutorService.ts
@@ -1,0 +1,54 @@
+/*!
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import { createLogger } from '../../../logging';
+import BootService from '../boot/BootService';
+import { AgentCommand } from './CommandService';
+
+const logger = createLogger(__filename);
+
+/** Java {@code CommandExecutorService} — routes commands; unknown commands are logged only. */
+export default class CommandExecutorService implements BootService {
+  private readonly executors = new Map<string, (command: AgentCommand) => void>();
+
+  prepare(): void {}
+
+  boot(): void {}
+
+  onComplete(): void {}
+
+  shutdown(): void {}
+
+  priority(): number {
+    return 0;
+  }
+
+  registerExecutor(commandName: string, executor: (command: AgentCommand) => void): void {
+    this.executors.set(commandName, executor);
+  }
+
+  execute(command: AgentCommand): void {
+    const executor = this.executors.get(command.name);
+    if (executor) {
+      executor(command);
+      return;
+    }
+    logger.warn('Received unsupported command [%s]; ignored (Java NoopCommandExecutor parity).', command.name);
+  }
+}

--- a/src/agent/core/commands/CommandSerialNumberCache.ts
+++ b/src/agent/core/commands/CommandSerialNumberCache.ts
@@ -17,20 +17,24 @@
  *
  */
 
-import * as grpc from '@grpc/grpc-js';
-import ChannelBuilder, { ChannelBuildContext } from './ChannelBuilder';
+/** Java {@code CommandSerialNumberCache}. */
+export default class CommandSerialNumberCache {
+  private readonly maxCapacity: number;
 
-const MAX_INBOUND_MESSAGE_SIZE = 1024 * 1024 * 50;
+  private readonly queue: string[] = [];
 
-export default class StandardChannelBuilder implements ChannelBuilder {
-  build(context: ChannelBuildContext): ChannelBuildContext {
-    return {
-      ...context,
-      options: {
-        ...context.options,
-        'grpc.max_receive_message_length': MAX_INBOUND_MESSAGE_SIZE,
-        'grpc.max_send_message_length': MAX_INBOUND_MESSAGE_SIZE,
-      },
-    };
+  constructor(maxCapacity = 64) {
+    this.maxCapacity = maxCapacity;
+  }
+
+  add(serialNumber: string): void {
+    if (this.queue.length >= this.maxCapacity) {
+      this.queue.shift();
+    }
+    this.queue.push(serialNumber);
+  }
+
+  contain(serialNumber: string): boolean {
+    return this.queue.includes(serialNumber);
   }
 }

--- a/src/agent/core/commands/CommandService.ts
+++ b/src/agent/core/commands/CommandService.ts
@@ -1,0 +1,148 @@
+/*!
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import { createLogger } from '../../../logging';
+import { Command, Commands } from '../../../proto/common/Common_pb';
+import BootService from '../boot/BootService';
+import ServiceManager from '../boot/ServiceManager';
+import CommandExecutorService from './CommandExecutorService';
+import CommandSerialNumberCache from './CommandSerialNumberCache';
+
+const logger = createLogger(__filename);
+
+const MAX_COMMAND_QUEUE = 64;
+
+export type AgentCommand = {
+  name: string;
+  serialNumber: string;
+  args: Map<string, string>;
+};
+
+export function parseAgentCommand(command: Command): AgentCommand {
+  const args = new Map<string, string>();
+  let serialNumber = '';
+  for (const pair of command.getArgsList()) {
+    const key = pair.getKey();
+    const value = pair.getValue();
+    args.set(key, value);
+    if (key === 'SerialNumber') {
+      serialNumber = value;
+    }
+  }
+  return {
+    name: command.getCommand(),
+    serialNumber,
+    args,
+  };
+}
+
+/** Java {@code CommandService}. */
+export default class CommandService implements BootService {
+  private running = false;
+
+  private readonly queue: AgentCommand[] = [];
+
+  private readonly serialNumberCache = new CommandSerialNumberCache();
+
+  private drainScheduled = false;
+
+  prepare(): void {}
+
+  boot(): void {
+    this.running = true;
+  }
+
+  onComplete(): void {}
+
+  shutdown(): void {
+    this.running = false;
+    this.queue.length = 0;
+  }
+
+  priority(): number {
+    return 0;
+  }
+
+  receiveCommand(commands: Commands | null | undefined): void {
+    if (!commands || !this.running) {
+      return;
+    }
+
+    for (const command of commands.getCommandsList()) {
+      try {
+        const agentCommand = parseAgentCommand(command);
+        if (!agentCommand.serialNumber) {
+          logger.warn('Command [%s] missing SerialNumber; ignored.', agentCommand.name);
+          continue;
+        }
+        if (this.serialNumberCache.contain(agentCommand.serialNumber)) {
+          logger.warn('Command [%s] is executed, ignored', agentCommand.name);
+          continue;
+        }
+        if (this.queue.length >= MAX_COMMAND_QUEUE) {
+          logger.warn(
+            'Command [%s, %s] cannot add to command list because the command list is full.',
+            agentCommand.name,
+            agentCommand.serialNumber,
+          );
+          continue;
+        }
+        this.queue.push(agentCommand);
+      } catch (error) {
+        logger.error('Failed to parse OAP command: %s', error);
+      }
+    }
+
+    this.scheduleDrain();
+  }
+
+  private scheduleDrain(): void {
+    if (this.drainScheduled || !this.running) {
+      return;
+    }
+    this.drainScheduled = true;
+    setImmediate(() => {
+      this.drainScheduled = false;
+      this.drainQueue();
+    });
+  }
+
+  private drainQueue(): void {
+    const executor = ServiceManager.INSTANCE.findService(CommandExecutorService);
+    if (!executor) {
+      return;
+    }
+
+    while (this.queue.length > 0) {
+      const command = this.queue.shift();
+      if (!command) {
+        break;
+      }
+      if (this.serialNumberCache.contain(command.serialNumber)) {
+        continue;
+      }
+      try {
+        executor.execute(command);
+        this.serialNumberCache.add(command.serialNumber);
+      } catch (error) {
+        logger.error('Failed to execute command [%s]: %s', command.name, error);
+      }
+    }
+  }
+}

--- a/src/agent/core/meter/MeterSender.ts
+++ b/src/agent/core/meter/MeterSender.ts
@@ -26,11 +26,19 @@ import ServiceManager from '../boot/ServiceManager';
 import RuntimeMetricsCollector from './RuntimeMetricsCollector';
 import { RuntimeSnapshot } from './RuntimeSampler';
 import GRPCChannelManager from '../remote/GRPCChannelManager';
+import { grpcUpstreamDeadlineMs } from '../remote/GrpcUpstreamOptions';
 import { GRPCChannelListener } from '../remote/GRPCChannelListener';
 import { GRPCChannelStatus } from '../remote/GRPCChannelStatus';
+import CommandService from '../commands/CommandService';
+import { Commands } from '../../../proto/common/Common_pb';
 
 const logger = createLogger(__filename);
 const logReportError = throttled(logger, 'error', 30000);
+
+/**
+ * Java JVMMetricsSender drains the full queue in one unary RPC.
+ * Node/grpc-js uses client streaming — drain at most one snapshot per report tick.
+ */
 
 /** Reports Node.js runtime metrics via gRPC MeterReportService (Go/Python-compatible pipeline). */
 export default class MeterSender implements BootService, GRPCChannelListener {
@@ -42,7 +50,6 @@ export default class MeterSender implements BootService, GRPCChannelListener {
   private collectTimer?: NodeJS.Timeout;
   private reportTimer?: NodeJS.Timeout;
   private reporting?: Promise<void>;
-
   private collector!: RuntimeMetricsCollector;
 
   prepare(): void {
@@ -77,7 +84,7 @@ export default class MeterSender implements BootService, GRPCChannelListener {
     }
 
     return new MeterReportServiceClient(
-      config.collectorAddress,
+      this.channelManager.resolveAddress(),
       grpc.credentials.createInsecure(),
       this.channelManager.getClientOptions(),
     );
@@ -100,12 +107,30 @@ export default class MeterSender implements BootService, GRPCChannelListener {
     this.reportTimer.unref();
   }
 
+  private maxBufferSize(): number {
+    return config.runtimeMetricsBufferSize || 600;
+  }
+
   private collectSample(): void {
-    const maxBufferSize = config.runtimeMetricsBufferSize || 600;
+    const maxBufferSize = this.maxBufferSize();
     if (this.buffer.length >= maxBufferSize) {
       this.buffer.shift();
     }
     this.buffer.push(this.collector.sample());
+  }
+
+  /** Re-queue failed snapshots while enforcing the same cap as collectSample(). */
+  private requeueSnapshots(snapshots: RuntimeSnapshot[]): void {
+    if (snapshots.length === 0) {
+      return;
+    }
+    const maxBufferSize = this.maxBufferSize();
+    const combined = [...snapshots, ...this.buffer];
+    if (combined.length > maxBufferSize) {
+      combined.splice(0, combined.length - maxBufferSize);
+    }
+    this.buffer.length = 0;
+    this.buffer.push(...combined);
   }
 
   private reportBufferedMetrics(): Promise<void> {
@@ -120,12 +145,34 @@ export default class MeterSender implements BootService, GRPCChannelListener {
     this.reporting = this.doReportBufferedMetrics().finally(() => {
       this.reporting = undefined;
     });
-
     return this.reporting;
   }
 
   private doReportBufferedMetrics(): Promise<void> {
     return new Promise((resolve) => {
+      let snapshots: RuntimeSnapshot[] = [];
+      let settled = false;
+      let stream: ReturnType<MeterReportServiceClient['collect']> | undefined;
+      let writesStarted = false;
+
+      const settle = (error?: unknown): void => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        if (error != null) {
+          if (!this.handleMeterReportError(error)) {
+            logReportError('Failed to report runtime meter data', error);
+            this.reportGrpcError(error);
+          }
+          // Java JVMMetricsSender discards drained metrics on failure; re-queue only before stream writes.
+          if (!this.closed && !writesStarted) {
+            this.requeueSnapshots(snapshots);
+          }
+        }
+        resolve();
+      };
+
       try {
         if (this.closed) {
           resolve();
@@ -142,46 +189,46 @@ export default class MeterSender implements BootService, GRPCChannelListener {
           return;
         }
 
-        const snapshots = this.buffer.splice(0, this.buffer.length);
-        const stream = this.reporterClient.collect(
+        const maxSnapshots = config.runtimeMetricsMaxSnapshotsPerReport ?? 1;
+        snapshots = this.buffer.splice(0, Math.min(this.buffer.length, maxSnapshots));
+        const batch = snapshots;
+
+        stream = this.reporterClient.collect(
           new grpc.Metadata(),
-          { deadline: Date.now() + (config.traceTimeout || 10000) },
-          (error: grpc.ServiceError | null) => {
+          { deadline: grpcUpstreamDeadlineMs() },
+          (error: grpc.ServiceError | null, commands?: Commands | null) => {
             if (error) {
-              logReportError('Failed to report runtime meter data', error);
-              this.reportGrpcError(error);
+              settle(error);
+            } else {
+              ServiceManager.INSTANCE.findService(CommandService)?.receiveCommand(commands ?? undefined);
+              settle();
             }
-            resolve();
           },
         );
 
-        try {
-          let metadataWritten = false;
-          const timestamp = Date.now();
-          for (const snapshot of snapshots) {
-            for (const meterData of this.collector.toMeterData(snapshot)) {
-              if (!metadataWritten) {
-                meterData
-                  .setService(config.serviceName)
-                  .setServiceinstance(config.serviceInstance)
-                  .setTimestamp(timestamp);
-                metadataWritten = true;
-              }
-              stream.write(meterData);
+        for (const snapshot of batch) {
+          for (const meterData of this.collector.toMeterData(snapshot)) {
+            if (this.closed) {
+              break;
+            }
+            meterData
+              .setService(config.serviceName)
+              .setServiceinstance(config.serviceInstance)
+              .setTimestamp(snapshot.collectedAt);
+            const writeAccepted = stream.write(meterData);
+            writesStarted = true;
+            if (writeAccepted === false) {
+              logger.warn('Meter stream backpressure; dropping remaining meters in this report tick');
+              break;
             }
           }
-        } finally {
-          try {
-            stream.end();
-          } catch (error) {
-            logReportError('Failed to end meter collect stream', error);
-            resolve();
-          }
+        }
+
+        if (stream) {
+          stream.end();
         }
       } catch (error) {
-        logReportError('Failed to report runtime meter data', error);
-        this.reportGrpcError(error);
-        resolve();
+        settle(error);
       }
     });
   }
@@ -194,10 +241,23 @@ export default class MeterSender implements BootService, GRPCChannelListener {
     this.channelManager?.reportError(error);
   }
 
-  flush(): Promise<any> | null {
+  /** Java MeterSender: disable reporting when OAP has no MeterReportService. */
+  private handleMeterReportError(error: unknown): boolean {
+    const code = (error as grpc.ServiceError | undefined)?.code;
+    if (code !== grpc.status.UNIMPLEMENTED) {
+      return false;
+    }
+
+    logger.warn("Backend doesn't support meter report; runtime meter reporting will be disabled.");
+    this.shutdown();
+    return true;
+  }
+
+  flush(): Promise<void> | null {
     if (this.closed) {
       return null;
     }
+
     this.collectSample();
     return this.reportBufferedMetrics();
   }

--- a/src/agent/core/meter/RuntimeMetricsCollector.ts
+++ b/src/agent/core/meter/RuntimeMetricsCollector.ts
@@ -36,6 +36,12 @@ export default class RuntimeMetricsCollector {
       ['instance_nodejs_heap_limit', snapshot.heapSizeLimit],
       ['instance_nodejs_rss', snapshot.rss],
       ['instance_nodejs_external_memory', snapshot.external],
+      ['instance_nodejs_array_buffers', snapshot.arrayBuffers],
+      ['instance_nodejs_uptime', snapshot.uptime],
+      ['instance_nodejs_peak_malloced_memory', snapshot.peakMallocedMemory],
+      ['instance_nodejs_detached_contexts', snapshot.detachedContexts],
+      ['instance_nodejs_old_space_used', snapshot.oldSpaceUsed],
+      ['instance_nodejs_new_space_used', snapshot.newSpaceUsed],
     ];
 
     return gauges.map(([name, value]) =>

--- a/src/agent/core/meter/RuntimeSampler.ts
+++ b/src/agent/core/meter/RuntimeSampler.ts
@@ -19,8 +19,10 @@
 
 import os from 'os';
 import v8 from 'v8';
+import config from '../../../config/AgentConfig';
 
 export type RuntimeSnapshot = {
+  collectedAt: number;
   heapUsed: number;
   heapTotal: number;
   heapSizeLimit: number;
@@ -28,6 +30,12 @@ export type RuntimeSnapshot = {
   external: number;
   cpuUserPercent: number;
   cpuSystemPercent: number;
+  arrayBuffers: number;
+  uptime: number;
+  peakMallocedMemory: number;
+  detachedContexts: number;
+  oldSpaceUsed: number;
+  newSpaceUsed: number;
 };
 
 export default class RuntimeSampler {
@@ -47,8 +55,17 @@ export default class RuntimeSampler {
     const cpuScale = elapsedMicros > 0 ? 100 / elapsedMicros / this.logicalCpuCount : 0;
     const cpuUserPercent = cpuUsage.user * cpuScale;
     const cpuSystemPercent = cpuUsage.system * cpuScale;
+    const heapSpaceDetail = config.runtimeMetricsHeapSpaceDetail !== false;
+    const heapSpaceUsed = (spaceName: string): number => {
+      if (!heapSpaceDetail) {
+        return 0;
+      }
+      const heapSpaces = v8.getHeapSpaceStatistics();
+      return heapSpaces.find((entry) => entry.space_name === spaceName)?.space_used_size ?? 0;
+    };
 
     return {
+      collectedAt: Date.now(),
       heapUsed: memory.heapUsed,
       heapTotal: memory.heapTotal,
       heapSizeLimit: heapStats.heap_size_limit,
@@ -56,6 +73,12 @@ export default class RuntimeSampler {
       external: memory.external,
       cpuUserPercent,
       cpuSystemPercent,
+      arrayBuffers: memory.arrayBuffers ?? 0,
+      uptime: process.uptime(),
+      peakMallocedMemory: heapStats.peak_malloced_memory,
+      detachedContexts: heapStats.number_of_detached_contexts,
+      oldSpaceUsed: heapSpaceUsed('old_space'),
+      newSpaceUsed: heapSpaceUsed('new_space'),
     };
   }
 

--- a/src/agent/core/remote/BackendAddressResolver.ts
+++ b/src/agent/core/remote/BackendAddressResolver.ts
@@ -1,0 +1,222 @@
+/*!
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import { promises as dnsPromises } from 'dns';
+import net from 'net';
+import { createLogger } from '../../../logging';
+
+const logger = createLogger(__filename);
+
+/** Cap DNS expansion to avoid unbounded memory on hostile or misconfigured resolvers. */
+export const MAX_DNS_LOOKUP_RECORDS = 64;
+
+/** Abort slow DNS lookups so channel checks do not stall the event loop. */
+export const DNS_LOOKUP_TIMEOUT_MS = 5_000;
+
+/** Resolved gRPC target with optional TLS SNI hostname (H-2 per-entry mapping). */
+export interface BackendTarget {
+  target: string;
+  /** Hostname for grpc.ssl_target_name_override when target is a resolved IP. */
+  tlsServerName?: string;
+}
+
+export type DnsLookupFn = (
+  hostname: string,
+  options: { all: true; verbatim?: boolean },
+) => Promise<Array<{ address: string; family: number }>>;
+
+const defaultLookup: DnsLookupFn = (hostname, options) =>
+  dnsPromises.lookup(hostname, options) as ReturnType<DnsLookupFn>;
+
+export async function lookupBackendHostRecords(
+  hostname: string,
+  lookup: DnsLookupFn = defaultLookup,
+  timeoutMs: number = DNS_LOOKUP_TIMEOUT_MS,
+): Promise<Array<{ address: string; family: number }>> {
+  let timeoutHandle: NodeJS.Timeout | undefined;
+  try {
+    const records = await Promise.race([
+      lookup(hostname, { all: true, verbatim: true }),
+      new Promise<never>((_, reject) => {
+        timeoutHandle = setTimeout(() => reject(new Error('DNS lookup timeout')), timeoutMs);
+        timeoutHandle.unref();
+      }),
+    ]);
+    if (records.length > MAX_DNS_LOOKUP_RECORDS) {
+      logger.warn('DNS returned %s records for %s; using first %s', records.length, hostname, MAX_DNS_LOOKUP_RECORDS);
+      return records.slice(0, MAX_DNS_LOOKUP_RECORDS);
+    }
+    return records;
+  } finally {
+    if (timeoutHandle) {
+      clearTimeout(timeoutHandle);
+    }
+  }
+}
+
+/** Parse comma-separated backend entries (Java BACKEND_SERVICE split). */
+export function parseStaticBackendAddresses(raw: string): string[] {
+  return raw
+    .split(',')
+    .map((entry) => entry.trim())
+    .filter(Boolean)
+    .filter(isValidHostPortEntry);
+}
+
+function isValidHostPortEntry(entry: string): boolean {
+  try {
+    const { host, port } = splitHostPort(entry);
+    const portNum = Number.parseInt(port, 10);
+    return Boolean(host) && !Number.isNaN(portNum) && portNum > 0 && portNum <= 65535;
+  } catch {
+    logger.debug('Service address [%s] format error. Expected host:port', entry);
+    return false;
+  }
+}
+
+/** Split host:port, supporting bracketed IPv6 literals such as [::1]:11800. */
+export function splitHostPort(entry: string): { host: string; port: string } {
+  const trimmed = entry.trim();
+  if (!trimmed) {
+    throw new Error(`Invalid host:port entry: ${entry}`);
+  }
+  if (trimmed.startsWith('[')) {
+    const close = trimmed.indexOf(']');
+    if (close < 0 || trimmed[close + 1] !== ':') {
+      throw new Error(`Invalid host:port entry: ${entry}`);
+    }
+    return { host: trimmed.slice(1, close), port: trimmed.slice(close + 2) };
+  }
+  const lastColon = trimmed.lastIndexOf(':');
+  if (lastColon <= 0) {
+    throw new Error(`Invalid host:port entry: ${entry}`);
+  }
+  return { host: trimmed.slice(0, lastColon), port: trimmed.slice(lastColon + 1) };
+}
+
+/** Format host:port for grpc target strings; IPv6 hosts are bracketed. */
+export function formatHostPort(host: string, port: string | number): string {
+  const portText = String(port);
+  if (net.isIPv6(host)) {
+    return `[${host}]:${portText}`;
+  }
+  return `${host}:${portText}`;
+}
+
+export function isLiteralIp(host: string): boolean {
+  return net.isIP(host) !== 0;
+}
+
+/**
+ * Expand backend entries to targets (Java InetAddress.getAllByName).
+ * When resolveDns=false, returns static entries only.
+ * DNS-expanded IPs carry tlsServerName from the source hostname for grpc-js SNI.
+ */
+export async function expandBackendAddresses(
+  entries: string[],
+  resolveDns: boolean,
+  lookup: DnsLookupFn = defaultLookup,
+): Promise<BackendTarget[]> {
+  const byTarget = new Map<string, BackendTarget>();
+
+  const addTarget = (item: BackendTarget): void => {
+    const existing = byTarget.get(item.target);
+    if (!existing) {
+      byTarget.set(item.target, item);
+      return;
+    }
+    if (existing.tlsServerName && item.tlsServerName && existing.tlsServerName !== item.tlsServerName) {
+      logger.warn(
+        'Target %s resolves from multiple hostnames (%s vs %s); TLS SNI uses %s',
+        item.target,
+        existing.tlsServerName,
+        item.tlsServerName,
+        existing.tlsServerName,
+      );
+    }
+  };
+
+  for (const entry of entries) {
+    if (!isValidHostPortEntry(entry)) {
+      continue;
+    }
+    const { host, port } = splitHostPort(entry);
+
+    if (!resolveDns || isLiteralIp(host)) {
+      addTarget({ target: formatHostPort(host, port) });
+      continue;
+    }
+
+    try {
+      const records = await lookupBackendHostRecords(host, lookup);
+      for (const record of records) {
+        addTarget({
+          target: formatHostPort(record.address, port),
+          tlsServerName: isLiteralIp(record.address) ? host : undefined,
+        });
+      }
+    } catch (error) {
+      logger.error('Failed to resolve %s of backend service.', host, error);
+    }
+  }
+
+  return Array.from(byTarget.values());
+}
+
+/**
+ * Fallback TLS SNI when per-target tlsServerName is unavailable (legacy / static IP lists).
+ * Prefer {@link BackendTarget.tlsServerName} from {@link expandBackendAddresses}.
+ */
+
+/** Count distinct non-IP hostnames in collectorAddress (comma-separated). */
+export function countDistinctNonIpHostnames(raw: string): number {
+  const hosts = new Set<string>();
+  for (const entry of parseStaticBackendAddresses(raw)) {
+    const { host } = splitHostPort(entry);
+    if (host && !isLiteralIp(host)) {
+      hosts.add(host.toLowerCase());
+    }
+  }
+  return hosts.size;
+}
+
+let multiHostnameTlsWarned = false;
+
+/** @deprecated Multi-hostname TLS SNI is handled per {@link BackendTarget}; kept for API compat. */
+export function warnMultiHostnameTlsConstraint(_collectorAddress: string): void {
+  // no-op: per-target tlsServerName mapping supersedes first-hostname-only SNI
+}
+
+/** @internal test hook */
+export function resetMultiHostnameTlsWarnForTest(): void {
+  multiHostnameTlsWarned = false;
+}
+
+export function deriveTlsServerNameForConnectHost(connectHost: string, collectorAddress: string): string | undefined {
+  if (!isLiteralIp(connectHost)) {
+    return undefined;
+  }
+  for (const entry of parseStaticBackendAddresses(collectorAddress)) {
+    const { host } = splitHostPort(entry);
+    if (host && !isLiteralIp(host)) {
+      return host;
+    }
+  }
+  return undefined;
+}

--- a/src/agent/core/remote/ChannelBuilder.ts
+++ b/src/agent/core/remote/ChannelBuilder.ts
@@ -23,6 +23,10 @@ import * as grpc from '@grpc/grpc-js';
 export interface ChannelBuildContext {
   credentials: grpc.ChannelCredentials;
   options: grpc.ChannelOptions;
+  /** Physical connect host (may be IP after DNS re-resolve). */
+  connectHost?: string;
+  /** Explicit TLS SNI hostname (from DNS-expanded BackendTarget). */
+  tlsServerName?: string;
 }
 
 export default interface ChannelBuilder {

--- a/src/agent/core/remote/GRPCChannel.ts
+++ b/src/agent/core/remote/GRPCChannel.ts
@@ -21,22 +21,31 @@ import * as grpc from '@grpc/grpc-js';
 import { ClientOptions, connectivityState } from '@grpc/grpc-js';
 import ChannelBuilder, { ChannelBuildContext } from './ChannelBuilder';
 import ChannelDecorator from './ChannelDecorator';
+import { formatHostPort } from './BackendAddressResolver';
 
 export default class GRPCChannel {
   private readonly originChannel: grpc.Channel;
   private readonly interceptors: grpc.Interceptor[];
 
-  private constructor(host: string, port: number, channelBuilders: ChannelBuilder[], decorators: ChannelDecorator[]) {
+  private constructor(
+    host: string,
+    port: number,
+    channelBuilders: ChannelBuilder[],
+    decorators: ChannelDecorator[],
+    tlsServerName?: string,
+  ) {
     let context: ChannelBuildContext = {
       credentials: grpc.credentials.createInsecure(),
       options: {},
+      connectHost: host,
+      tlsServerName,
     };
 
     for (const builder of channelBuilders) {
       context = builder.build(context);
     }
 
-    this.originChannel = new grpc.Channel(`${host}:${port}`, context.credentials, context.options);
+    this.originChannel = new grpc.Channel(formatHostPort(host, port), context.credentials, context.options);
     this.interceptors = decorators.map((decorator) => decorator.build());
   }
 
@@ -45,12 +54,13 @@ export default class GRPCChannel {
     port: number,
     channelBuilders: ChannelBuilder[],
     decorators: ChannelDecorator[],
+    tlsServerName?: string,
   ): GRPCChannel {
-    return new GRPCChannel(host, port, channelBuilders, decorators);
+    return new GRPCChannel(host, port, channelBuilders, decorators, tlsServerName);
   }
 
-  static newBuilder(host: string, port: number): GRPCChannelBuilder {
-    return new GRPCChannelBuilder(host, port);
+  static newBuilder(host: string, port: number, tlsServerName?: string): GRPCChannelBuilder {
+    return new GRPCChannelBuilder(host, port, tlsServerName);
   }
 
   getChannel(): grpc.Channel {
@@ -76,12 +86,14 @@ export default class GRPCChannel {
 class GRPCChannelBuilder {
   private readonly host: string;
   private readonly port: number;
+  private readonly tlsServerName?: string;
   private readonly channelBuilders: ChannelBuilder[] = [];
   private readonly decorators: ChannelDecorator[] = [];
 
-  constructor(host: string, port: number) {
+  constructor(host: string, port: number, tlsServerName?: string) {
     this.host = host;
     this.port = port;
+    this.tlsServerName = tlsServerName;
   }
 
   addManagedChannelBuilder(builder: ChannelBuilder): this {
@@ -95,6 +107,6 @@ class GRPCChannelBuilder {
   }
 
   build(): GRPCChannel {
-    return GRPCChannel.create(this.host, this.port, this.channelBuilders, this.decorators);
+    return GRPCChannel.create(this.host, this.port, this.channelBuilders, this.decorators, this.tlsServerName);
   }
 }

--- a/src/agent/core/remote/GRPCChannelManager.ts
+++ b/src/agent/core/remote/GRPCChannelManager.ts
@@ -23,52 +23,69 @@ import config from '../../../config/AgentConfig';
 import { createLogger } from '../../../logging';
 import AgentIDDecorator from './AgentIDDecorator';
 import AuthenticationDecorator from './AuthenticationDecorator';
+import {
+  BackendTarget,
+  deriveTlsServerNameForConnectHost,
+  expandBackendAddresses,
+  formatHostPort,
+  parseStaticBackendAddresses,
+  splitHostPort,
+} from './BackendAddressResolver';
 import GRPCChannel from './GRPCChannel';
 import { GRPCChannelListener } from './GRPCChannelListener';
 import { GRPCChannelStatus } from './GRPCChannelStatus';
 import BootService from '../boot/BootService';
 import StandardChannelBuilder from './StandardChannelBuilder';
-import TLSChannelBuilder from './TLSChannelBuilder';
+import TLSChannelBuilder, { isTlsEnabled, preloadTlsMaterials } from './TLSChannelBuilder';
+import { clearTlsMaterialCacheOnShutdown } from './TlsMaterialCache';
 
 const logger = createLogger(__filename);
 
-function isGrpcNetworkError(error: unknown): boolean {
+function isGrpcAuthError(error: unknown): boolean {
   const code = (error as grpc.ServiceError | undefined)?.code;
-
-  return (
-    code === grpc.status.UNAVAILABLE ||
-    code === grpc.status.PERMISSION_DENIED ||
-    code === grpc.status.UNAUTHENTICATED ||
-    code === grpc.status.RESOURCE_EXHAUSTED ||
-    code === grpc.status.UNKNOWN
-  );
+  return code === grpc.status.PERMISSION_DENIED || code === grpc.status.UNAUTHENTICATED;
 }
 
-/**
- * Shared gRPC channel manager (Java GRPCChannelManager skeleton).
- * V1: single address; V2 reserved: multi-address failover via reportError().
- */
+function isGrpcNetworkError(error: unknown): boolean {
+  const code = (error as grpc.ServiceError | undefined)?.code;
+  if (isGrpcAuthError(error)) {
+    return false;
+  }
+  return code === grpc.status.UNAVAILABLE || code === grpc.status.RESOURCE_EXHAUSTED || code === grpc.status.UNKNOWN;
+}
+
+/** Shared gRPC channel manager aligned with Java GRPCChannelManager (v2 DNS re-resolve). */
 export default class GRPCChannelManager implements BootService {
   private managedChannel: GRPCChannel | null = null;
   private readonly listeners: GRPCChannelListener[] = [];
   private lastStatus: GRPCChannelStatus | null = null;
   private closed = false;
+  private reconnect = true;
+  private grpcServers: BackendTarget[] = [];
+  private selectedIdx = -1;
+  private reconnectCount = 0;
+  private currentTarget: string | null = null;
+  private checkTimer?: NodeJS.Timeout;
+  private checkInFlight = false;
+  private watcherGeneration = 0;
 
-  /** V1: first address when comma-separated; V2: failover selection. */
+  /** Logical target for gRPC client stubs (hostname when channel uses resolved IP). */
   resolveAddress(): string {
-    const raw = config.collectorAddress ?? '';
-    const first = raw.split(',')[0]?.trim();
-    if (!first) {
+    const target = this.currentTarget ?? parseStaticBackendAddresses(config.collectorAddress ?? '')[0];
+    if (!target) {
       throw new Error('collectorAddress is not configured');
     }
-    return first;
+    const { host, port } = splitHostPort(target);
+    const backend = this.grpcServers.find((entry) => entry.target === target);
+    const logicalHost =
+      backend?.tlsServerName ?? deriveTlsServerNameForConnectHost(host, config.collectorAddress ?? '') ?? host;
+    return formatHostPort(logicalHost, port);
   }
 
   getChannel(): grpc.Channel {
     if (!this.managedChannel) {
       throw new Error('gRPC channel is not available');
     }
-
     return this.managedChannel.getChannel();
   }
 
@@ -76,7 +93,6 @@ export default class GRPCChannelManager implements BootService {
     if (!this.managedChannel) {
       throw new Error('gRPC channel is not available');
     }
-
     return this.managedChannel.getClientOptions();
   }
 
@@ -95,18 +111,29 @@ export default class GRPCChannelManager implements BootService {
     return Number.MAX_SAFE_INTEGER;
   }
 
-  /** Align local status with grpc-js connectivity; avoid permanent DISCONNECT while channel stays READY. */
+  /** Align with grpc-js connectivity; avoid permanent DISCONNECT while channel stays READY. */
   reportError(error: unknown): void {
+    if (isGrpcAuthError(error)) {
+      logger.warn('gRPC authentication rejected by OAP; fix SW_AGENT_AUTHENTICATION (no reconnect): %s', String(error));
+      return;
+    }
     if (!isGrpcNetworkError(error)) {
       logger.debug('gRPC report error (ignored): %s', error);
       return;
     }
+    if (this.closed) {
+      return;
+    }
 
     const managed = this.managedChannel;
-    if (!managed || this.closed) {
+    if (!managed) {
+      logger.debug('gRPC network error without channel, schedule reconnect: %s', error);
+      this.reconnect = true;
       this.notify(GRPCChannelStatus.DISCONNECT);
       return;
     }
+
+    this.reconnect = true;
 
     if (managed.isConnected(false)) {
       logger.debug('gRPC network error but channel still connected: %s', error);
@@ -114,7 +141,7 @@ export default class GRPCChannelManager implements BootService {
       return;
     }
 
-    logger.debug('gRPC network error, notify DISCONNECT: %s', error);
+    logger.debug('gRPC network error, schedule reconnect: %s', error);
     this.notify(GRPCChannelStatus.DISCONNECT);
   }
 
@@ -122,34 +149,171 @@ export default class GRPCChannelManager implements BootService {
 
   boot(): void {
     this.closed = false;
-    const address = this.resolveAddress();
-    const [host, portText] = address.split(':');
-    const port = Number.parseInt(portText, 10);
-
-    if (!host || Number.isNaN(port)) {
-      throw new Error(`Invalid collector address: ${address}`);
+    this.grpcServers = parseStaticBackendAddresses(config.collectorAddress ?? '').map((target) => ({ target }));
+    if (this.grpcServers.length === 0) {
+      logger.error('Collector server addresses are not set.');
+      logger.error('Agent will not uplink any data.');
+      return;
     }
-
-    this.managedChannel = GRPCChannel.newBuilder(host, port)
-      .addManagedChannelBuilder(new StandardChannelBuilder())
-      .addManagedChannelBuilder(new TLSChannelBuilder())
-      .addChannelDecorator(new AgentIDDecorator())
-      .addChannelDecorator(new AuthenticationDecorator())
-      .build();
-
-    this.watchConnectivityState();
-    this.notifyCurrentConnectivityState(true);
+    this.reconnect = true;
+    const intervalMs = (config.grpcChannelCheckInterval ?? 30) * 1000;
+    this.checkTimer = setInterval(() => {
+      void this.runCheck();
+    }, intervalMs);
+    this.checkTimer.unref();
+    void this.runCheck();
   }
 
   onComplete(): void {}
 
   shutdown(): void {
     this.closed = true;
+    if (this.checkTimer) {
+      clearInterval(this.checkTimer);
+      this.checkTimer = undefined;
+    }
+    this.watcherGeneration += 1;
     const managed = this.managedChannel;
     this.managedChannel = null;
     managed?.shutdownNow();
     this.notify(GRPCChannelStatus.DISCONNECT);
     this.listeners.length = 0;
+    this.grpcServers = [];
+    this.selectedIdx = -1;
+    this.currentTarget = null;
+    this.reconnect = true;
+    clearTlsMaterialCacheOnShutdown();
+  }
+
+  /** Java GRPCChannelManager.run() — exposed for unit tests. */
+  async runCheck(): Promise<void> {
+    if (this.closed || this.checkInFlight) {
+      return;
+    }
+    this.checkInFlight = true;
+    try {
+      logger.debug('gRPC channel check running, reconnect: %s', this.reconnect);
+
+      // grpc-js may keep READY after TCP teardown; probe before reconnect-only early return.
+      if (this.managedChannel && !this.managedChannel.isConnected(false)) {
+        this.reconnect = true;
+      }
+
+      if (config.isResolveDnsPeriodically && this.reconnect) {
+        const staticEntries = parseStaticBackendAddresses(config.collectorAddress ?? '');
+        this.grpcServers = await expandBackendAddresses(staticEntries, true);
+        if (this.closed) {
+          return;
+        }
+      } else if (this.grpcServers.length === 0) {
+        this.grpcServers = parseStaticBackendAddresses(config.collectorAddress ?? '').map((target) => ({ target }));
+      }
+
+      if (!this.reconnect || this.closed) {
+        return;
+      }
+
+      if (this.grpcServers.length === 0) {
+        logger.debug('No collector backend available. Wait %s seconds to retry', config.grpcChannelCheckInterval ?? 30);
+        return;
+      }
+
+      // Java parity: rebuild channel only when random index != selectedIdx.
+      // Same index with a changed resolved ip:port does NOT trigger rebuild (see Java GRPCChannelManager.run()).
+      const index = Math.abs(Math.floor(Math.random() * this.grpcServers.length));
+      if (index !== this.selectedIdx) {
+        await this.switchToServer(this.grpcServers[index]!, index);
+        return;
+      }
+
+      const forceReconnect = ++this.reconnectCount > (config.forceReconnectionPeriod ?? 1);
+      if (this.managedChannel?.isConnected(forceReconnect)) {
+        this.reconnectCount = 0;
+        this.reconnect = false;
+        this.notifyCurrentConnectivityState(true);
+        return;
+      }
+
+      // Same index but backend unreachable — rotate (needed for DNS-expanded ip:port lists).
+      if (this.grpcServers.length > 1 && this.selectedIdx >= 0 && !this.managedChannel?.isConnected(false)) {
+        const nextIdx = (this.selectedIdx + 1) % this.grpcServers.length;
+        await this.switchToServer(this.grpcServers[nextIdx]!, nextIdx);
+      }
+    } catch (error) {
+      logger.error('gRPC channel check failed: %s', error);
+    } finally {
+      this.checkInFlight = false;
+    }
+  }
+
+  /** @internal test hook */
+  getReconnectStateForTest(): boolean {
+    return this.reconnect;
+  }
+
+  /** @internal test hook */
+  getGrpcServersForTest(): BackendTarget[] {
+    return this.grpcServers.map((entry) => ({ ...entry }));
+  }
+
+  /** @internal test hook */
+  getSelectedIdxForTest(): number {
+    return this.selectedIdx;
+  }
+
+  /** @internal test hook */
+  getReconnectCountForTest(): number {
+    return this.reconnectCount;
+  }
+
+  /** @internal test hook */
+  getLastStatusForTest(): GRPCChannelStatus | null {
+    return this.lastStatus;
+  }
+
+  /** @internal test hook */
+  hasCheckTimerForTest(): boolean {
+    return this.checkTimer !== undefined;
+  }
+
+  private async switchToServer(backend: BackendTarget, index: number): Promise<void> {
+    if (this.closed) {
+      return;
+    }
+
+    const target = backend.target;
+    const { host, port: portText } = splitHostPort(target);
+    const port = Number.parseInt(portText, 10);
+    if (!host || Number.isNaN(port)) {
+      throw new Error(`Invalid collector address: ${target}`);
+    }
+
+    this.watcherGeneration += 1;
+    const previous = this.managedChannel;
+    this.managedChannel = null;
+    previous?.shutdownNow();
+
+    try {
+      // Java TLSChannelBuilder reads TLS files on every channel rebuild.
+      await preloadTlsMaterials();
+
+      this.managedChannel = GRPCChannel.newBuilder(host, port, backend.tlsServerName)
+        .addManagedChannelBuilder(new StandardChannelBuilder())
+        .addManagedChannelBuilder(new TLSChannelBuilder())
+        .addChannelDecorator(new AgentIDDecorator())
+        .addChannelDecorator(new AuthenticationDecorator())
+        .build();
+    } catch (error) {
+      logger.error('Failed to build gRPC channel for target [%s]: %s', target, error);
+      return;
+    }
+
+    this.selectedIdx = index;
+    this.currentTarget = backend.target;
+    this.reconnectCount = 0;
+    this.reconnect = false;
+    this.watchConnectivityState();
+    this.notifyCurrentConnectivityState(true);
   }
 
   private watchConnectivityState(): void {
@@ -157,20 +321,17 @@ export default class GRPCChannelManager implements BootService {
     if (this.closed || !managed) {
       return;
     }
-
+    const generation = this.watcherGeneration;
     const channel = managed.getChannel();
     const currentState = channel.getConnectivityState(true);
-
-    channel.watchConnectivityState(currentState, Infinity, (error) => {
-      if (this.closed || this.managedChannel !== managed) {
+    channel.watchConnectivityState(currentState, Date.now() + 86_400_000, (error) => {
+      if (this.closed || this.managedChannel !== managed || this.watcherGeneration !== generation) {
         return;
       }
-
       if (error) {
         logger.debug('Channel connectivity watch stopped: %s', error.message);
         return;
       }
-
       this.notifyCurrentConnectivityState(false);
       this.watchConnectivityState();
     });
@@ -181,7 +342,6 @@ export default class GRPCChannelManager implements BootService {
     if (this.closed || !managed) {
       return;
     }
-
     const channel = managed.getChannel();
     const ready = channel.getConnectivityState(requestConnection) === grpc.connectivityState.READY;
     this.notify(ready ? GRPCChannelStatus.CONNECTED : GRPCChannelStatus.DISCONNECT);

--- a/src/agent/core/remote/GrpcUpstreamOptions.ts
+++ b/src/agent/core/remote/GrpcUpstreamOptions.ts
@@ -17,20 +17,10 @@
  *
  */
 
-import * as grpc from '@grpc/grpc-js';
-import ChannelBuilder, { ChannelBuildContext } from './ChannelBuilder';
+import config from '../../../config/AgentConfig';
 
-const MAX_INBOUND_MESSAGE_SIZE = 1024 * 1024 * 50;
-
-export default class StandardChannelBuilder implements ChannelBuilder {
-  build(context: ChannelBuildContext): ChannelBuildContext {
-    return {
-      ...context,
-      options: {
-        ...context.options,
-        'grpc.max_receive_message_length': MAX_INBOUND_MESSAGE_SIZE,
-        'grpc.max_send_message_length': MAX_INBOUND_MESSAGE_SIZE,
-      },
-    };
-  }
+/** Java {@code Config.Collector.GRPC_UPSTREAM_TIMEOUT} — upstream gRPC call deadline (ms). */
+export function grpcUpstreamDeadlineMs(): number {
+  const seconds = config.grpcUpstreamTimeout ?? 30;
+  return Date.now() + seconds * 1000;
 }

--- a/src/agent/core/remote/ServiceManagementClient.ts
+++ b/src/agent/core/remote/ServiceManagementClient.ts
@@ -28,8 +28,10 @@ import { ManagementServiceClient } from '../../../proto/management/Management_gr
 import { InstancePingPkg, InstanceProperties } from '../../../proto/management/Management_pb';
 import { KeyStringValuePair } from '../../../proto/common/Common_pb';
 import GRPCChannelManager from './GRPCChannelManager';
+import { grpcUpstreamDeadlineMs } from './GrpcUpstreamOptions';
 import { GRPCChannelListener } from './GRPCChannelListener';
 import { GRPCChannelStatus } from './GRPCChannelStatus';
+import CommandService from '../commands/CommandService';
 
 const logger = createLogger(__filename);
 const logHeartbeatError = throttled(logger, 'error', 30000);
@@ -74,7 +76,8 @@ export default class ServiceManagementClient implements BootService, GRPCChannel
         new KeyStringValuePair().setKey('Process No.').setValue(`${process.pid}`),
       ]);
 
-    this.heartbeatTimer = setInterval(() => this.sendHeartbeat(), 20000) as NodeJS.Timeout;
+    const heartbeatPeriodMs = (config.collectorHeartbeatPeriod ?? 20) * 1000;
+    this.heartbeatTimer = setInterval(() => this.sendHeartbeat(), heartbeatPeriodMs) as NodeJS.Timeout;
     this.heartbeatTimer.unref();
   }
 
@@ -111,7 +114,7 @@ export default class ServiceManagementClient implements BootService, GRPCChannel
       return;
     }
 
-    const options = { deadline: Date.now() + config.traceTimeout };
+    const options = { deadline: grpcUpstreamDeadlineMs() };
     const reportProperties =
       Math.abs(this.sendPropertiesCounter++) % ServiceManagementClient.PROPERTIES_REPORT_PERIOD_FACTOR === 0;
 
@@ -120,21 +123,25 @@ export default class ServiceManagementClient implements BootService, GRPCChannel
         this.instanceProperties,
         new grpc.Metadata(),
         options,
-        (error) => {
+        (error, commands) => {
           if (error) {
             logHeartbeatError('Failed to send instance properties', error);
             this.reportGrpcError(error);
+            return;
           }
+          ServiceManager.INSTANCE.findService(CommandService)?.receiveCommand(commands);
         },
       );
       return;
     }
 
-    this.managementServiceClient.keepAlive(this.keepAlivePkg, new grpc.Metadata(), options, (error) => {
+    this.managementServiceClient.keepAlive(this.keepAlivePkg, new grpc.Metadata(), options, (error, commands) => {
       if (error) {
         logHeartbeatError('Failed to send heartbeat', error);
         this.reportGrpcError(error);
+        return;
       }
+      ServiceManager.INSTANCE.findService(CommandService)?.receiveCommand(commands);
     });
   }
 
@@ -144,11 +151,12 @@ export default class ServiceManagementClient implements BootService, GRPCChannel
     }
 
     return new ManagementServiceClient(
-      config.collectorAddress,
+      this.channelManager.resolveAddress(),
       grpc.credentials.createInsecure(),
       this.channelManager.getClientOptions(),
     );
   }
+
   private reportGrpcError(error: unknown): void {
     if (this.closed) {
       return;

--- a/src/agent/core/remote/TLSChannelBuilder.ts
+++ b/src/agent/core/remote/TLSChannelBuilder.ts
@@ -19,17 +19,84 @@
 
 import * as grpc from '@grpc/grpc-js';
 import config from '../../../config/AgentConfig';
+import { createLogger } from '../../../logging';
 import ChannelBuilder, { ChannelBuildContext } from './ChannelBuilder';
+import { deriveTlsServerNameForConnectHost } from './BackendAddressResolver';
+import { getTlsMaterials, isCaFileAvailableFromPreload } from './TlsMaterialCache';
 
-/** When SW_AGENT_SECURE=true, upgrade channel credentials to TLS (Java TLSChannelBuilder simplified). */
+const logger = createLogger(__filename);
+
+/** {@code SW_AGENT_FORCE_TLS} or {@code SW_AGENT_SECURE} (Node extension of Java force_tls). */
+function isTlsRequiredByConfig(): boolean {
+  return Boolean(config.forceTls || config.secure);
+}
+
+/**
+ * Java {@code TLSChannelBuilder}: {@code FORCE_TLS || caFileExists} enables TLS negotiation.
+ * CA presence comes from async {@link preloadTlsMaterials} (no sync stat on the event loop).
+ */
+function shouldUseTls(): boolean {
+  return isTlsRequiredByConfig() || Boolean(getTlsMaterials()?.rootCerts) || isCaFileAvailableFromPreload();
+}
+
+export function isTlsEnabled(): boolean {
+  return shouldUseTls();
+}
+
+/**
+ * If only ca.crt exists, start TLS. If cert, key and ca files exist, enable mTLS.
+ * Aligned with Java {@code TLSChannelBuilder}. TLS files must be preloaded via
+ * {@link preloadTlsMaterials} before channel build when a CA file is present.
+ */
 export default class TLSChannelBuilder implements ChannelBuilder {
   build(context: ChannelBuildContext): ChannelBuildContext {
-    if (config.secure) {
-      return {
-        ...context,
-        credentials: grpc.credentials.createSsl(),
-      };
+    if (!shouldUseTls()) {
+      return context;
     }
-    return context;
+
+    const materials = getTlsMaterials();
+    const rootCerts = materials?.rootCerts ?? null;
+    const privateKey = materials?.privateKey ?? null;
+    const certChain = materials?.certChain ?? null;
+
+    let credentials: grpc.ChannelCredentials;
+
+    if (rootCerts) {
+      if (Boolean(config.sslCertChainPath) && Boolean(config.sslKeyPath)) {
+        if (!privateKey || !certChain) {
+          logger.error('mTLS configured but client cert or key material is unavailable; refusing channel build.');
+          throw new Error('mTLS material unavailable');
+        }
+        credentials = grpc.credentials.createSsl(rootCerts, privateKey, certChain);
+      } else {
+        credentials = grpc.credentials.createSsl(rootCerts, privateKey, certChain);
+      }
+    } else if (isTlsRequiredByConfig()) {
+      logger.warn(
+        'TLS enabled without trusted CA file (SW_AGENT_FORCE_TLS); using system trust store (Java force_tls parity).',
+      );
+      credentials = grpc.credentials.createSsl();
+    } else {
+      logger.error('TLS required but trusted CA material is unavailable; refusing insecure channel.');
+      throw new Error('TLS material unavailable');
+    }
+
+    const options: grpc.ChannelOptions = { ...context.options };
+    const tlsServerName =
+      context.tlsServerName ??
+      (context.connectHost
+        ? deriveTlsServerNameForConnectHost(context.connectHost, config.collectorAddress ?? '')
+        : undefined);
+    if (tlsServerName) {
+      options['grpc.ssl_target_name_override'] = tlsServerName;
+    }
+
+    return {
+      ...context,
+      credentials,
+      options,
+    };
   }
 }
+
+export { preloadTlsMaterials } from './TlsMaterialCache';

--- a/src/agent/core/remote/TlsMaterialCache.ts
+++ b/src/agent/core/remote/TlsMaterialCache.ts
@@ -1,0 +1,210 @@
+/*!
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import fs from 'fs';
+import { promises as fsPromises } from 'fs';
+import config from '../../../config/AgentConfig';
+import { getAgentPackagePath, isPathInsideAgentRoot, resolveAgentPath } from '../boot/AgentPackagePath';
+import path from 'path';
+import { loadDecryptionKeyFromBuffer } from '../util/PrivateKeyUtil';
+import { createLogger } from '../../../logging';
+
+const logger = createLogger(__filename);
+
+/** Max TLS PEM/CA file size (256 KiB) to limit memory DoS. */
+const MAX_TLS_MATERIAL_BYTES = 256 * 1024;
+
+export type TlsMaterialSnapshot = {
+  rootCerts: Buffer | null;
+  privateKey: Buffer | null;
+  certChain: Buffer | null;
+};
+
+/** Last preload result consumed by {@code TLSChannelBuilder.build()} in the same rebuild. */
+let cachedSnapshot: TlsMaterialSnapshot | null = null;
+
+/** Whether the trusted CA file existed on the last {@link preloadTlsMaterials} call. */
+let caFileExistsOnLastPreload = false;
+
+/** Read a regular file; reject symlinks (B-1 path traversal via link). */
+async function readRegularFileBytes(
+  filePath: string,
+  options: { mustStayUnderAgentRoot?: boolean; requirePrivateKeyMode?: boolean } = {},
+): Promise<Buffer | null> {
+  try {
+    const lstat = await fsPromises.lstat(filePath);
+    if (lstat.isSymbolicLink()) {
+      logger.warn('TLS path [%s] is a symbolic link; refusing to load', filePath);
+      return null;
+    }
+    if (!lstat.isFile()) {
+      return null;
+    }
+    if (lstat.size > MAX_TLS_MATERIAL_BYTES) {
+      logger.warn('TLS path [%s] exceeds max size %d bytes; refusing to load', filePath, MAX_TLS_MATERIAL_BYTES);
+      return null;
+    }
+    if (options.requirePrivateKeyMode && (lstat.mode & 0o077) !== 0) {
+      logger.warn(
+        'Private key [%s] is group/world accessible (mode %o); refusing to load',
+        filePath,
+        lstat.mode & 0o777,
+      );
+      return null;
+    }
+    const realPath = await fsPromises.realpath(filePath);
+    if (options.mustStayUnderAgentRoot && !isPathInsideAgentRoot(realPath)) {
+      logger.warn('TLS path [%s] resolves outside agent package [%s]; refusing to load', filePath, realPath);
+      return null;
+    }
+    const openFlags = fs.constants.O_RDONLY | (fs.constants.O_NOFOLLOW ?? 0);
+    const handle = await fsPromises.open(filePath, openFlags);
+    try {
+      return await handle.readFile();
+    } finally {
+      await handle.close();
+    }
+  } catch {
+    return null;
+  }
+}
+
+async function isRegularFilePath(filePath: string): Promise<boolean> {
+  try {
+    const lstat = await fsPromises.lstat(filePath);
+    return lstat.isFile() && !lstat.isSymbolicLink();
+  } catch {
+    return false;
+  }
+}
+
+function resolveConfiguredPath(configuredPath: string | undefined): string | undefined {
+  if (!configuredPath) {
+    return undefined;
+  }
+  try {
+    return resolveAgentPath(configuredPath);
+  } catch (error) {
+    logger.error('Invalid TLS path [%s]: %s', configuredPath, error);
+    return undefined;
+  }
+}
+
+async function readFileIfExists(configuredPath: string | undefined): Promise<Buffer | null> {
+  const filePath = resolveConfiguredPath(configuredPath);
+  if (!filePath) {
+    return null;
+  }
+  const mustStay = !path.isAbsolute((configuredPath ?? '').trim());
+  return readRegularFileBytes(filePath, { mustStayUnderAgentRoot: mustStay });
+}
+
+async function readPrivateKeyIfExists(configuredPath: string | undefined): Promise<Buffer | null> {
+  const filePath = resolveConfiguredPath(configuredPath);
+  if (!filePath) {
+    return null;
+  }
+  const mustStay = !path.isAbsolute((configuredPath ?? '').trim());
+  const keyBytes = await readRegularFileBytes(filePath, {
+    mustStayUnderAgentRoot: mustStay,
+    requirePrivateKeyMode: true,
+  });
+  if (!keyBytes) {
+    return null;
+  }
+  try {
+    return loadDecryptionKeyFromBuffer(keyBytes);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Async-load TLS files before channel rebuild (Java {@code TLSChannelBuilder} reads on every build).
+ * Reloads from disk on each call so rotated certificates are picked up after failover/reconnect.
+ */
+async function probeCaFileExists(): Promise<boolean> {
+  const filePath = resolveConfiguredPath(config.sslTrustedCaPath);
+  if (!filePath) {
+    return false;
+  }
+  if (!(await isRegularFilePath(filePath))) {
+    return false;
+  }
+  if (!path.isAbsolute((config.sslTrustedCaPath ?? '').trim())) {
+    try {
+      const realPath = await fsPromises.realpath(filePath);
+      return isPathInsideAgentRoot(realPath);
+    } catch {
+      return false;
+    }
+  }
+  return true;
+}
+
+export async function preloadTlsMaterials(): Promise<TlsMaterialSnapshot> {
+  caFileExistsOnLastPreload = await probeCaFileExists();
+  const rootCerts = await readFileIfExists(config.sslTrustedCaPath);
+  let privateKey = await readPrivateKeyIfExists(config.sslKeyPath);
+  let certChain = await readFileIfExists(config.sslCertChainPath);
+
+  const certPathSet = Boolean(config.sslCertChainPath);
+  const keyPathSet = Boolean(config.sslKeyPath);
+  if (certPathSet && keyPathSet && (!privateKey || !certChain)) {
+    privateKey = null;
+    certChain = null;
+  } else if (certPathSet !== keyPathSet) {
+    privateKey = null;
+    certChain = null;
+  }
+
+  cachedSnapshot = { rootCerts, privateKey, certChain };
+  return cachedSnapshot;
+}
+
+export function getTlsMaterials(): TlsMaterialSnapshot | null {
+  return cachedSnapshot;
+}
+
+/** Whether trusted CA file existed during the last preload (replaces sync stat in TLSChannelBuilder). */
+export function isCaFileAvailableFromPreload(): boolean {
+  return caFileExistsOnLastPreload;
+}
+
+/** @internal test hook — reset preload cache between tests. */
+function zeroSensitiveBuffers(snapshot: TlsMaterialSnapshot | null): void {
+  if (!snapshot) {
+    return;
+  }
+  if (snapshot.privateKey) {
+    snapshot.privateKey.fill(0);
+  }
+}
+
+/** Java reads TLS from disk on each channel rebuild; clear cached key material on agent shutdown. */
+export function clearTlsMaterialCacheOnShutdown(): void {
+  zeroSensitiveBuffers(cachedSnapshot);
+  cachedSnapshot = null;
+  caFileExistsOnLastPreload = false;
+}
+
+/** @internal test hook */
+export function clearTlsMaterialCacheForTest(): void {
+  clearTlsMaterialCacheOnShutdown();
+}

--- a/src/agent/core/remote/TraceSegmentServiceClient.ts
+++ b/src/agent/core/remote/TraceSegmentServiceClient.ts
@@ -26,8 +26,10 @@ import { TraceSegmentReportServiceClient } from '../../../proto/language-agent/T
 import { emitter } from '../../../lib/EventEmitter';
 import Segment from '../../../trace/context/Segment';
 import GRPCChannelManager from './GRPCChannelManager';
+import { grpcUpstreamDeadlineMs } from './GrpcUpstreamOptions';
 import { GRPCChannelListener } from './GRPCChannelListener';
 import { GRPCChannelStatus } from './GRPCChannelStatus';
+import CommandService from '../commands/CommandService';
 
 const logger = createLogger(__filename);
 const logReportError = throttled(logger, 'error', 30000);
@@ -64,7 +66,6 @@ export default class TraceSegmentServiceClient implements BootService, GRPCChann
       }
 
       this.buffer.push(segment);
-      this.timeout?.ref();
     };
 
     emitter.on('segment-finished', this.segmentFinishedListener);
@@ -80,6 +81,7 @@ export default class TraceSegmentServiceClient implements BootService, GRPCChann
     this.closed = true;
     if (this.segmentFinishedListener) {
       emitter.off('segment-finished', this.segmentFinishedListener);
+      this.segmentFinishedListener = undefined;
     }
 
     if (this.timeout) {
@@ -109,7 +111,7 @@ export default class TraceSegmentServiceClient implements BootService, GRPCChann
     }
 
     return new TraceSegmentReportServiceClient(
-      config.collectorAddress,
+      this.channelManager.resolveAddress(),
       grpc.credentials.createInsecure(),
       this.channelManager.getClientOptions(),
     );
@@ -142,7 +144,6 @@ export default class TraceSegmentServiceClient implements BootService, GRPCChann
     this.reporting = this.doReport().finally(() => {
       this.reporting = undefined;
     });
-
     return this.reporting;
   }
 
@@ -165,42 +166,87 @@ export default class TraceSegmentServiceClient implements BootService, GRPCChann
         return;
       }
 
+      let snapshots: Segment[] = [];
+      let settled = false;
       let stream: ReturnType<TraceSegmentReportServiceClient['collect']> | undefined;
-      try {
-        stream = this.reporterClient.collect(
-          new grpc.Metadata(),
-          { deadline: Date.now() + config.traceTimeout },
-          (error) => {
-            if (error) {
-              logReportError('Failed to report trace data', error);
-              this.reportGrpcError(error);
-            }
-            resolve();
-          },
-        );
+      let writesStarted = false;
 
-        for (const segment of this.buffer) {
-          if (segment) {
-            if (logger._isDebugEnabled) {
-              logger.debug('Sending segment ', { segment });
-            }
-            stream.write(segment.transform());
+      const settle = (error?: unknown): void => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        if (error != null) {
+          logReportError('Failed to report trace data', error);
+          this.reportGrpcError(error);
+          if (!this.closed && !writesStarted) {
+            this.requeueSegments(snapshots);
           }
         }
-      } catch (error) {
-        logReportError('Failed to report trace data', error);
-        this.reportGrpcError(error);
         resolve();
-      } finally {
-        this.buffer.length = 0;
+      };
+
+      void (async () => {
         try {
-          stream?.end();
+          snapshots = this.buffer.splice(0, this.buffer.length);
+
+          stream = this.reporterClient!.collect(
+            new grpc.Metadata(),
+            { deadline: grpcUpstreamDeadlineMs() },
+            (error, commands) => {
+              if (error) {
+                settle(error);
+              } else {
+                ServiceManager.INSTANCE.findService(CommandService)?.receiveCommand(commands);
+                settle();
+              }
+            },
+          );
+
+          for (const segment of snapshots) {
+            if (this.closed) {
+              break;
+            }
+            if (segment) {
+              if (logger._isDebugEnabled) {
+                logger.debug(
+                  'Sending segment traceId=%s segmentId=%s spanCount=%d',
+                  segment.relatedTraces[0]?.toString?.() ?? 'unknown',
+                  segment.segmentId.toString(),
+                  segment.spans.length,
+                );
+              }
+              let writeAccepted = stream.write(segment.transform());
+              writesStarted = true;
+              while (writeAccepted === false && stream && !this.closed) {
+                await new Promise<void>((resolveDrain) => stream!.once('drain', resolveDrain));
+                writeAccepted = true;
+              }
+            }
+          }
+
+          if (stream) {
+            stream.end();
+          }
         } catch (error) {
-          logReportError('Failed to end trace collect stream', error);
-          resolve();
+          settle(error);
         }
-      }
+      })();
     });
+  }
+
+  /** Re-queue failed segments while enforcing the same cap as segmentFinished listener. */
+  private requeueSegments(segments: Segment[]): void {
+    if (segments.length === 0) {
+      return;
+    }
+    const maxBufferSize = config.maxBufferSize;
+    for (const segment of segments) {
+      while (this.buffer.length >= maxBufferSize) {
+        this.buffer.shift();
+      }
+      this.buffer.push(segment);
+    }
   }
 
   private reportGrpcError(error: unknown): void {

--- a/src/agent/core/util/PrivateKeyUtil.ts
+++ b/src/agent/core/util/PrivateKeyUtil.ts
@@ -1,0 +1,96 @@
+/*!
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import fs from 'fs';
+import { promises as fsPromises } from 'fs';
+
+const PKCS_1_PEM_HEADER = '-----BEGIN RSA PRIVATE KEY-----';
+const PKCS_1_PEM_FOOTER = '-----END RSA PRIVATE KEY-----';
+const PKCS_8_PEM_HEADER = '-----BEGIN PRIVATE KEY-----';
+const PKCS_8_PEM_FOOTER = '-----END PRIVATE KEY-----';
+
+/**
+ * Load a RSA private key from PEM bytes (PKCS#1 or PKCS#8).
+ * Aligned with Java {@code PrivateKeyUtil.loadDecryptionKey}.
+ */
+export function loadDecryptionKeyFromBuffer(keyDataBytes: Buffer): Buffer {
+  let keyDataString = keyDataBytes.toString('utf8');
+
+  if (keyDataString.includes(PKCS_1_PEM_HEADER)) {
+    keyDataString = keyDataString.replace(PKCS_1_PEM_HEADER, '');
+    keyDataString = keyDataString.replace(PKCS_1_PEM_FOOTER, '');
+    keyDataString = keyDataString.replace(/\n/g, '');
+    const pkcs1Bytes = Buffer.from(keyDataString, 'base64');
+    return readPkcs1PrivateKey(pkcs1Bytes);
+  }
+
+  return keyDataBytes;
+}
+
+/**
+ * Load a RSA private key from a file (PEM PKCS#1 or PKCS#8).
+ * Aligned with Java {@code PrivateKeyUtil.loadDecryptionKey}.
+ */
+/** Preferred for runtime TLS loading (non-blocking). */
+export async function loadDecryptionKeyAsync(keyFilePath: string): Promise<Buffer> {
+  return loadDecryptionKeyFromBuffer(await fsPromises.readFile(keyFilePath));
+}
+
+/** Synchronous loader retained for unit tests and legacy callers. */
+export function loadDecryptionKey(keyFilePath: string): Buffer {
+  return loadDecryptionKeyFromBuffer(fs.readFileSync(keyFilePath));
+}
+
+/** Convert raw PKCS#1 bytes into PKCS#8 PEM (Java readPkcs1PrivateKey). */
+function readPkcs1PrivateKey(pkcs1Bytes: Buffer): Buffer {
+  const pkcs1Length = pkcs1Bytes.length;
+  const totalLength = pkcs1Length + 22;
+  const pkcs8Header = Buffer.from([
+    0x30,
+    0x82,
+    (totalLength >> 8) & 0xff,
+    totalLength & 0xff,
+    0x02,
+    0x01,
+    0x00,
+    0x30,
+    0x0d,
+    0x06,
+    0x09,
+    0x2a,
+    0x86,
+    0x48,
+    0x86,
+    0xf7,
+    0x0d,
+    0x01,
+    0x01,
+    0x01,
+    0x05,
+    0x00,
+    0x04,
+    0x82,
+    (pkcs1Length >> 8) & 0xff,
+    pkcs1Length & 0xff,
+  ]);
+  const der = Buffer.concat([pkcs8Header, pkcs1Bytes]);
+  const pemBody = der.toString('base64');
+  const pem = `${PKCS_8_PEM_HEADER}\n${pemBody}\n${PKCS_8_PEM_FOOTER}\n`;
+  return Buffer.from(pem, 'utf8');
+}

--- a/src/config/AgentConfig.ts
+++ b/src/config/AgentConfig.ts
@@ -18,12 +18,20 @@
  */
 
 import * as os from 'os';
+import { createLogger } from '../logging';
+const logger = createLogger(__filename);
 
 export type AgentConfig = {
   serviceName?: string;
   serviceInstance?: string;
   collectorAddress?: string;
+  /** Legacy TLS switch; maps to forceTls. FORCE_TLS without CA may use system trust store (Java parity). */
   secure?: boolean;
+  /** Prefer explicit CA file; Java may enable TLS with FORCE_TLS alone, Node does not. */
+  forceTls?: boolean;
+  sslTrustedCaPath?: string;
+  sslCertChainPath?: string;
+  sslKeyPath?: string;
   authorization?: string;
   maxBufferSize?: number;
   coldEndpoint?: boolean;
@@ -43,10 +51,18 @@ export type AgentConfig = {
   reIgnoreOperation?: RegExp;
   reHttpIgnoreMethod?: RegExp;
   traceTimeout?: number;
+  grpcUpstreamTimeout?: number;
   runtimeMetricsReporterActive?: boolean;
   runtimeMetricsCollectPeriod?: number;
   runtimeMetricsReportPeriod?: number;
   runtimeMetricsBufferSize?: number;
+  runtimeMetricsMaxSnapshotsPerReport?: number;
+  runtimeMetricsHeapSpaceDetail?: boolean;
+  grpcChannelCheckInterval?: number;
+  /** Java {@code Config.Collector.HEARTBEAT_PERIOD} (seconds). */
+  collectorHeartbeatPeriod?: number;
+  forceReconnectionPeriod?: number;
+  isResolveDnsPeriodically?: boolean;
   /** @deprecated use runtimeMetricsReporterActive */
   nvmMetricsReporterActive?: boolean;
   /** @deprecated use runtimeMetricsCollectPeriod */
@@ -154,8 +170,36 @@ function applyDeprecatedRuntimeMetricConfig(config: AgentConfig, options: AgentC
   clearDeprecatedRuntimeMetricFields(config);
 }
 
+function warnDeprecatedSecureEnv(): void {
+  if (process.env.SW_AGENT_SECURE?.toLowerCase() === 'true') {
+    logger.warn('SW_AGENT_SECURE is deprecated; use SW_AGENT_FORCE_TLS (Java only exposes agent.force_tls).');
+  }
+  for (const [oldName, newName] of [
+    ['SW_AGENT_NVM_METRICS_REPORTER_ACTIVE', 'SW_AGENT_RUNTIME_METRICS_REPORTER_ACTIVE'],
+    ['SW_AGENT_NVM_JVM_REPORTER_ACTIVE', 'SW_AGENT_RUNTIME_METRICS_REPORTER_ACTIVE'],
+    ['SW_AGENT_NODEJS_RUNTIME_METRICS_REPORTER_ACTIVE', 'SW_AGENT_RUNTIME_METRICS_REPORTER_ACTIVE'],
+    ['SW_AGENT_NODEJS_RUNTIME_METRICS_COLLECT_PERIOD', 'SW_AGENT_RUNTIME_METRICS_COLLECT_PERIOD'],
+    ['SW_AGENT_NODEJS_RUNTIME_METRICS_REPORT_PERIOD', 'SW_AGENT_RUNTIME_METRICS_REPORT_PERIOD'],
+    ['SW_AGENT_NODEJS_RUNTIME_METRICS_BUFFER_SIZE', 'SW_AGENT_RUNTIME_METRICS_BUFFER_SIZE'],
+    ['SW_AGENT_NVM_METRICS_COLLECT_PERIOD', 'SW_AGENT_RUNTIME_METRICS_COLLECT_PERIOD'],
+    ['SW_AGENT_NVM_JVM_METRICS_COLLECT_PERIOD', 'SW_AGENT_RUNTIME_METRICS_COLLECT_PERIOD'],
+    ['SW_AGENT_NVM_METRICS_REPORT_PERIOD', 'SW_AGENT_RUNTIME_METRICS_REPORT_PERIOD'],
+    ['SW_AGENT_NVM_JVM_METRICS_REPORT_PERIOD', 'SW_AGENT_RUNTIME_METRICS_REPORT_PERIOD'],
+    ['SW_AGENT_NVM_METRICS_BUFFER_SIZE', 'SW_AGENT_RUNTIME_METRICS_BUFFER_SIZE'],
+    ['SW_AGENT_NVM_JVM_METRICS_BUFFER_SIZE', 'SW_AGENT_RUNTIME_METRICS_BUFFER_SIZE'],
+  ]) {
+    if (process.env[oldName] !== undefined) {
+      logger.warn('Deprecated env %s; use %s', oldName, newName);
+    }
+  }
+}
+
 export function finalizeConfig(config: AgentConfig, options: AgentConfig = {}): void {
+  warnDeprecatedSecureEnv();
   applyDeprecatedRuntimeMetricConfig(config, options);
+  if (config.secure && !config.forceTls) {
+    config.forceTls = true;
+  }
 
   const escapeRegExp = (s: string) => s.replace(/([.*+?^=!:${}()|\[\]\/\\])/g, '\\$1');
 
@@ -228,7 +272,19 @@ const _config = {
       return os.hostname();
     })(),
   collectorAddress: process.env.SW_AGENT_COLLECTOR_BACKEND_SERVICES || '127.0.0.1:11800',
+  // Node requires a readable CA file before TLS (Java FORCE_TLS may use the system trust store).
+  /** @deprecated use forceTls / SW_AGENT_FORCE_TLS (Java agent.force_tls only) */
   secure: process.env.SW_AGENT_SECURE?.toLowerCase() === 'true',
+  forceTls: process.env.SW_AGENT_FORCE_TLS?.toLowerCase() === 'true',
+  sslTrustedCaPath: ((): string => {
+    const configured = process.env.SW_AGENT_SSL_TRUSTED_CA_PATH;
+    if (configured === undefined) {
+      return 'ca/ca.crt';
+    }
+    return configured;
+  })(),
+  sslCertChainPath: process.env.SW_AGENT_SSL_CERT_CHAIN_PATH ?? '',
+  sslKeyPath: process.env.SW_AGENT_SSL_KEY_PATH ?? '',
   authorization: process.env.SW_AGENT_AUTHENTICATION,
   maxBufferSize: ((n) => (Number.isSafeInteger(n) && n > 0 ? n : 1000))(
     Number.parseInt(process.env.SW_AGENT_MAX_BUFFER_SIZE ?? '', 10),
@@ -251,18 +307,29 @@ const _config = {
   traceTimeout: ((n) => (Number.isSafeInteger(n) && n > 0 ? n : 10 * 1000))(
     Number.parseInt(process.env.SW_AGENT_TRACE_TIMEOUT ?? '', 10),
   ),
+  grpcUpstreamTimeout: ((): number => {
+    const collectorTimeout = Number.parseInt(process.env.SW_AGENT_COLLECTOR_GRPC_UPSTREAM_TIMEOUT ?? '', 10);
+    if (Number.isSafeInteger(collectorTimeout) && collectorTimeout > 0) {
+      return collectorTimeout;
+    }
+    const legacyMs = Number.parseInt(process.env.SW_AGENT_TRACE_TIMEOUT ?? '', 10);
+    if (Number.isSafeInteger(legacyMs) && legacyMs > 0) {
+      return Math.max(1, Math.ceil(legacyMs / 1000));
+    }
+    return 30;
+  })(),
   runtimeMetricsReporterActive: ((): boolean => {
     const configured =
-      process.env.SW_AGENT_NODEJS_RUNTIME_METRICS_REPORTER_ACTIVE ??
       process.env.SW_AGENT_RUNTIME_METRICS_REPORTER_ACTIVE ??
+      process.env.SW_AGENT_NODEJS_RUNTIME_METRICS_REPORTER_ACTIVE ??
       process.env.SW_AGENT_NVM_METRICS_REPORTER_ACTIVE ??
       process.env.SW_AGENT_NVM_JVM_REPORTER_ACTIVE;
     return configured?.toLowerCase() !== 'false';
   })(),
   runtimeMetricsCollectPeriod: ((n) => (Number.isSafeInteger(n) && n > 0 ? n : 1000))(
     Number.parseInt(
-      process.env.SW_AGENT_NODEJS_RUNTIME_METRICS_COLLECT_PERIOD ??
-        process.env.SW_AGENT_RUNTIME_METRICS_COLLECT_PERIOD ??
+      process.env.SW_AGENT_RUNTIME_METRICS_COLLECT_PERIOD ??
+        process.env.SW_AGENT_NODEJS_RUNTIME_METRICS_COLLECT_PERIOD ??
         process.env.SW_AGENT_NVM_METRICS_COLLECT_PERIOD ??
         process.env.SW_AGENT_NVM_JVM_METRICS_COLLECT_PERIOD ??
         '',
@@ -271,8 +338,8 @@ const _config = {
   ),
   runtimeMetricsReportPeriod: ((n) => (Number.isSafeInteger(n) && n > 0 ? n : 1000))(
     Number.parseInt(
-      process.env.SW_AGENT_NODEJS_RUNTIME_METRICS_REPORT_PERIOD ??
-        process.env.SW_AGENT_RUNTIME_METRICS_REPORT_PERIOD ??
+      process.env.SW_AGENT_RUNTIME_METRICS_REPORT_PERIOD ??
+        process.env.SW_AGENT_NODEJS_RUNTIME_METRICS_REPORT_PERIOD ??
         process.env.SW_AGENT_NVM_METRICS_REPORT_PERIOD ??
         process.env.SW_AGENT_NVM_JVM_METRICS_REPORT_PERIOD ??
         '',
@@ -281,17 +348,52 @@ const _config = {
   ),
   runtimeMetricsBufferSize: ((n) => (Number.isSafeInteger(n) && n > 0 ? n : 600))(
     Number.parseInt(
-      process.env.SW_AGENT_NODEJS_RUNTIME_METRICS_BUFFER_SIZE ??
-        process.env.SW_AGENT_RUNTIME_METRICS_BUFFER_SIZE ??
+      process.env.SW_AGENT_RUNTIME_METRICS_BUFFER_SIZE ??
+        process.env.SW_AGENT_NODEJS_RUNTIME_METRICS_BUFFER_SIZE ??
         process.env.SW_AGENT_NVM_METRICS_BUFFER_SIZE ??
         process.env.SW_AGENT_NVM_JVM_METRICS_BUFFER_SIZE ??
         '',
       10,
     ),
   ),
+  runtimeMetricsMaxSnapshotsPerReport: ((n) => (Number.isSafeInteger(n) && n > 0 ? n : 1))(
+    Number.parseInt(process.env.SW_AGENT_RUNTIME_METRICS_MAX_SNAPSHOTS_PER_REPORT ?? '', 10),
+  ),
+  runtimeMetricsHeapSpaceDetail: ((): boolean => {
+    const configured = process.env.SW_AGENT_RUNTIME_METRICS_HEAP_SPACE_DETAIL;
+    return configured?.toLowerCase() !== 'false';
+  })(),
+  grpcChannelCheckInterval: ((n) => (Number.isSafeInteger(n) && n > 0 ? n : 30))(
+    Number.parseInt(process.env.SW_AGENT_GRPC_CHANNEL_CHECK_INTERVAL ?? '', 10),
+  ),
+  collectorHeartbeatPeriod: ((n) => (Number.isSafeInteger(n) && n > 0 ? n : 20))(
+    Number.parseInt(process.env.SW_AGENT_COLLECTOR_HEARTBEAT_PERIOD ?? '', 10),
+  ),
+  forceReconnectionPeriod: ((n) => (Number.isSafeInteger(n) && n > 0 ? n : 1))(
+    Number.parseInt(process.env.SW_AGENT_FORCE_RECONNECTION_PERIOD ?? '', 10),
+  ),
+  isResolveDnsPeriodically: process.env.SW_AGENT_IS_RESOLVE_DNS_PERIODICALLY?.toLowerCase() === 'true',
 };
 
 export default _config;
+
+/** Exported to applications; omits authorization token (B-4). */
+/* eslint-disable no-undef -- Proxy is a standard ES6 global */
+export const publicAgentConfig: Omit<AgentConfig, 'authorization'> = new Proxy(_config, {
+  get(target, prop, receiver) {
+    if (prop === 'authorization') {
+      return undefined;
+    }
+    const value = Reflect.get(target, prop, receiver);
+    return typeof value === 'function' ? (value as (...args: unknown[]) => unknown).bind(target) : value;
+  },
+  set(target, prop, value, receiver) {
+    if (prop === 'authorization') {
+      return false;
+    }
+    return Reflect.set(target, prop, value, receiver);
+  },
+});
 
 export function ignoreHttpMethodCheck(method: string): boolean {
   return Boolean(method.match(_config.reHttpIgnoreMethod));

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,13 +17,27 @@
  *
  */
 
-import config, { AgentConfig, finalizeConfig, normalizeDeprecatedRuntimeMetricOptions } from './config/AgentConfig';
+/* eslint-env node, es2020 */
+
+import agentConfig, {
+  AgentConfig,
+  finalizeConfig,
+  normalizeDeprecatedRuntimeMetricOptions,
+  publicAgentConfig,
+} from './config/AgentConfig';
 import ServiceManager from './agent/core/boot/ServiceManager';
 import { createLogger } from './logging';
 import PluginInstaller from './core/PluginInstaller';
 import SpanContext from './trace/context/SpanContext';
 
 const logger = createLogger(__filename);
+
+let bootstrapPromise: Promise<void> | null = null;
+
+/** Resolves when plugin install and ServiceManager.boot() complete. */
+export function whenReady(): Promise<void> {
+  return bootstrapPromise ?? Promise.resolve();
+}
 
 class Agent {
   private started = false;
@@ -39,26 +53,33 @@ class Agent {
       return;
     }
 
-    Object.assign(config, normalizeDeprecatedRuntimeMetricOptions(options));
-    finalizeConfig(config, options);
+    const normalizedOptions = normalizeDeprecatedRuntimeMetricOptions(options);
+    Object.assign(agentConfig, normalizedOptions);
+    finalizeConfig(agentConfig, normalizedOptions);
 
     logger.debug('Starting SkyWalking agent');
 
-    new PluginInstaller().install();
-
-    ServiceManager.INSTANCE.boot();
-    this.started = true;
+    try {
+      new PluginInstaller().install();
+      ServiceManager.INSTANCE.boot();
+      this.started = true;
+      bootstrapPromise = Promise.resolve();
+    } catch (error) {
+      const err = error instanceof Error ? error : new Error(String(error));
+      bootstrapPromise = Promise.reject(err);
+      logger.error('SkyWalking agent bootstrap failed: %s', err);
+    }
   }
 
-  flush(): Promise<any> | null {
+  flush(): Promise<unknown | null> {
     if (!this.started) {
       logger.warn('Trying to flush() SkyWalking agent which is not started.');
-      return null;
+      return Promise.resolve(null);
     }
 
     const spanContextFlush = SpanContext.flush();
     if (!spanContextFlush) {
-      return ServiceManager.INSTANCE.flush();
+      return ServiceManager.INSTANCE.flush() ?? Promise.resolve(null);
     }
 
     return new Promise((resolve) => {
@@ -71,19 +92,18 @@ class Agent {
   }
 
   destroy(): void {
-    if (!this.started) {
-      logger.warn('Trying to destroy() SkyWalking agent which is not started.');
-      return;
+    if (this.started) {
+      logger.info('Destroying SkyWalking agent and cleaning up resources');
+      ServiceManager.INSTANCE.shutdown();
+      this.started = false;
     }
-
-    logger.info('Destroying SkyWalking agent and cleaning up resources');
-    ServiceManager.INSTANCE.shutdown();
-    this.started = false;
+    bootstrapPromise = null;
   }
 }
 
 export default new Agent();
-export { default as config } from './config/AgentConfig';
+/** Agent config without SW_AGENT_AUTHENTICATION (B-4). Internal code uses AgentConfig default export. */
+export { publicAgentConfig as config };
 export { default as ContextManager } from './trace/context/ContextManager';
 export { default as AzureHttpTriggerPlugin } from './azure/AzureHttpTriggerPlugin';
 export { default as AWSLambdaTriggerPlugin } from './aws/AWSLambdaTriggerPlugin';

--- a/tests/config/AgentConfig.dns.test.ts
+++ b/tests/config/AgentConfig.dns.test.ts
@@ -1,0 +1,108 @@
+/*!
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+/* eslint-env jest */
+
+const mockLoggerWarn = jest.fn();
+jest.mock('../../src/logging', () => ({
+  createLogger: jest.fn(() => ({
+    warn: mockLoggerWarn,
+    info: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+  })),
+}));
+
+import config, { finalizeConfig } from '../../src/config/AgentConfig';
+
+describe('AgentConfig DNS / channel settings (Java collector.* parity)', () => {
+  const envBackup = { ...process.env };
+
+  afterEach(() => {
+    process.env = { ...envBackup };
+    jest.resetModules();
+  });
+
+  it('reads SW_AGENT_IS_RESOLVE_DNS_PERIODICALLY=true', () => {
+    process.env.SW_AGENT_IS_RESOLVE_DNS_PERIODICALLY = 'true';
+    jest.resetModules();
+    const cfg = require('../../src/config/AgentConfig').default;
+    expect(cfg.isResolveDnsPeriodically).toBe(true);
+  });
+
+  it('defaults SW_AGENT_IS_RESOLVE_DNS_PERIODICALLY to false', () => {
+    delete process.env.SW_AGENT_IS_RESOLVE_DNS_PERIODICALLY;
+    jest.resetModules();
+    const cfg = require('../../src/config/AgentConfig').default;
+    expect(cfg.isResolveDnsPeriodically).toBe(false);
+  });
+
+  it('reads SW_AGENT_GRPC_CHANNEL_CHECK_INTERVAL', () => {
+    process.env.SW_AGENT_GRPC_CHANNEL_CHECK_INTERVAL = '45';
+    jest.resetModules();
+    const cfg = require('../../src/config/AgentConfig').default;
+    expect(cfg.grpcChannelCheckInterval).toBe(45);
+  });
+
+  it('defaults SW_AGENT_GRPC_CHANNEL_CHECK_INTERVAL to 30 seconds', () => {
+    delete process.env.SW_AGENT_GRPC_CHANNEL_CHECK_INTERVAL;
+    jest.resetModules();
+    const cfg = require('../../src/config/AgentConfig').default;
+    expect(cfg.grpcChannelCheckInterval).toBe(30);
+  });
+
+  it('reads SW_AGENT_FORCE_RECONNECTION_PERIOD', () => {
+    process.env.SW_AGENT_FORCE_RECONNECTION_PERIOD = '3';
+    jest.resetModules();
+    const cfg = require('../../src/config/AgentConfig').default;
+    expect(cfg.forceReconnectionPeriod).toBe(3);
+  });
+
+  it('defaults SW_AGENT_FORCE_RECONNECTION_PERIOD to 1', () => {
+    delete process.env.SW_AGENT_FORCE_RECONNECTION_PERIOD;
+    jest.resetModules();
+    const cfg = require('../../src/config/AgentConfig').default;
+    expect(cfg.forceReconnectionPeriod).toBe(1);
+  });
+
+  it('reads SW_AGENT_COLLECTOR_GRPC_UPSTREAM_TIMEOUT', () => {
+    process.env.SW_AGENT_COLLECTOR_GRPC_UPSTREAM_TIMEOUT = '45';
+    jest.resetModules();
+    const cfg = require('../../src/config/AgentConfig').default;
+    expect(cfg.grpcUpstreamTimeout).toBe(45);
+  });
+
+  it('defaults grpcUpstreamTimeout to 30 seconds (Java GRPC_UPSTREAM_TIMEOUT)', () => {
+    delete process.env.SW_AGENT_COLLECTOR_GRPC_UPSTREAM_TIMEOUT;
+    delete process.env.SW_AGENT_TRACE_TIMEOUT;
+    jest.resetModules();
+    const cfg = require('../../src/config/AgentConfig').default;
+    expect(cfg.grpcUpstreamTimeout).toBe(30);
+  });
+  it('warns when SW_AGENT_NODEJS_RUNTIME_METRICS_COLLECT_PERIOD alias is set', () => {
+    mockLoggerWarn.mockClear();
+    process.env.SW_AGENT_NODEJS_RUNTIME_METRICS_COLLECT_PERIOD = '2000';
+    finalizeConfig(config);
+    expect(mockLoggerWarn).toHaveBeenCalledWith(
+      'Deprecated env %s; use %s',
+      'SW_AGENT_NODEJS_RUNTIME_METRICS_COLLECT_PERIOD',
+      'SW_AGENT_RUNTIME_METRICS_COLLECT_PERIOD',
+    );
+  });
+});

--- a/tests/config/AgentConfig.heartbeat.test.ts
+++ b/tests/config/AgentConfig.heartbeat.test.ts
@@ -17,20 +17,27 @@
  *
  */
 
-import * as grpc from '@grpc/grpc-js';
-import ChannelBuilder, { ChannelBuildContext } from './ChannelBuilder';
+/* eslint-env jest */
 
-const MAX_INBOUND_MESSAGE_SIZE = 1024 * 1024 * 50;
+describe('AgentConfig collector heartbeat period', () => {
+  const envBackup = { ...process.env };
 
-export default class StandardChannelBuilder implements ChannelBuilder {
-  build(context: ChannelBuildContext): ChannelBuildContext {
-    return {
-      ...context,
-      options: {
-        ...context.options,
-        'grpc.max_receive_message_length': MAX_INBOUND_MESSAGE_SIZE,
-        'grpc.max_send_message_length': MAX_INBOUND_MESSAGE_SIZE,
-      },
-    };
-  }
-}
+  afterEach(() => {
+    process.env = { ...envBackup };
+    jest.resetModules();
+  });
+
+  it('defaults to 20 seconds (Java HEARTBEAT_PERIOD)', () => {
+    delete process.env.SW_AGENT_COLLECTOR_HEARTBEAT_PERIOD;
+    jest.resetModules();
+    const config = require('../../src/config/AgentConfig').default;
+    expect(config.collectorHeartbeatPeriod).toBe(20);
+  });
+
+  it('reads SW_AGENT_COLLECTOR_HEARTBEAT_PERIOD in seconds', () => {
+    process.env.SW_AGENT_COLLECTOR_HEARTBEAT_PERIOD = '15';
+    jest.resetModules();
+    const config = require('../../src/config/AgentConfig').default;
+    expect(config.collectorHeartbeatPeriod).toBe(15);
+  });
+});

--- a/tests/config/AgentConfig.tls.test.ts
+++ b/tests/config/AgentConfig.tls.test.ts
@@ -1,0 +1,72 @@
+/*!
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+/* eslint-env jest */
+
+describe('AgentConfig TLS settings (Java agent.config parity)', () => {
+  const envBackup = { ...process.env };
+
+  afterEach(() => {
+    process.env = { ...envBackup };
+    jest.resetModules();
+  });
+
+  it('reads SW_AGENT_FORCE_TLS=true', () => {
+    process.env.SW_AGENT_FORCE_TLS = 'true';
+    jest.resetModules();
+    const cfg = require('../../src/config/AgentConfig').default;
+    expect(cfg.forceTls).toBe(true);
+  });
+
+  it('reads SW_AGENT_SSL_TRUSTED_CA_PATH', () => {
+    process.env.SW_AGENT_SSL_TRUSTED_CA_PATH = '/ca/ca.crt';
+    jest.resetModules();
+    const cfg = require('../../src/config/AgentConfig').default;
+    expect(cfg.sslTrustedCaPath).toBe('/ca/ca.crt');
+  });
+
+  it('reads SW_AGENT_SSL_CERT_CHAIN_PATH and SW_AGENT_SSL_KEY_PATH', () => {
+    process.env.SW_AGENT_SSL_CERT_CHAIN_PATH = '/ca/client.crt';
+    process.env.SW_AGENT_SSL_KEY_PATH = '/ca/client.key';
+    jest.resetModules();
+    const cfg = require('../../src/config/AgentConfig').default;
+    expect(cfg.sslCertChainPath).toBe('/ca/client.crt');
+    expect(cfg.sslKeyPath).toBe('/ca/client.key');
+  });
+
+  it('defaults SW_AGENT_SSL_TRUSTED_CA_PATH to ca/ca.crt', () => {
+    delete process.env.SW_AGENT_SSL_TRUSTED_CA_PATH;
+    jest.resetModules();
+    const cfg = require('../../src/config/AgentConfig').default;
+    expect(cfg.sslTrustedCaPath).toBe('ca/ca.crt');
+  });
+  it('reads SW_AGENT_SECURE=true', () => {
+    process.env.SW_AGENT_SECURE = 'true';
+    jest.resetModules();
+    const cfg = require('../../src/config/AgentConfig').default;
+    expect(cfg.secure).toBe(true);
+  });
+
+  it('defaults SW_AGENT_SECURE to false', () => {
+    delete process.env.SW_AGENT_SECURE;
+    jest.resetModules();
+    const cfg = require('../../src/config/AgentConfig').default;
+    expect(cfg.secure).toBe(false);
+  });
+});

--- a/tests/core/whenReady.test.ts
+++ b/tests/core/whenReady.test.ts
@@ -1,0 +1,79 @@
+/*!
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+/* eslint-env jest */
+
+jest.mock('../../src/core/PluginInstaller', () => ({
+  __esModule: true,
+  default: jest.fn().mockImplementation(() => ({
+    install: jest.fn(),
+  })),
+}));
+
+jest.mock('../../src/agent/core/boot/ServiceManager', () => ({
+  __esModule: true,
+  default: {
+    INSTANCE: {
+      boot: jest.fn(),
+      shutdown: jest.fn(),
+    },
+  },
+}));
+
+import agent, { whenReady, config } from '../../src/index';
+import ServiceManager from '../../src/agent/core/boot/ServiceManager';
+import PluginInstaller from '../../src/core/PluginInstaller';
+
+describe('whenReady', () => {
+  beforeEach(() => {
+    process.env.SW_DISABLE = 'false';
+    jest.clearAllMocks();
+    (PluginInstaller as jest.Mock).mockImplementation(() => ({
+      install: jest.fn(),
+    }));
+    agent.destroy();
+  });
+
+  it('resolves after bootstrap completes', async () => {
+    agent.start({});
+    await expect(whenReady()).resolves.toBeUndefined();
+    expect(ServiceManager.INSTANCE.boot).toHaveBeenCalled();
+  });
+
+  it('resolves immediately when agent was never started', async () => {
+    await expect(whenReady()).resolves.toBeUndefined();
+  });
+
+  it('rejects when bootstrap fails (B-2)', async () => {
+    (PluginInstaller as jest.Mock).mockImplementation(() => ({
+      install: jest.fn().mockImplementation(() => {
+        throw new Error('plugin install failed');
+      }),
+    }));
+    agent.start({});
+    await expect(whenReady()).rejects.toThrow('plugin install failed');
+    expect(ServiceManager.INSTANCE.boot).not.toHaveBeenCalled();
+  });
+
+  it('exported config omits authorization token (B-4)', async () => {
+    const internal = (await import('../../src/config/AgentConfig')).default;
+    internal.authorization = 'secret-token';
+    expect((config as Record<string, unknown>).authorization).toBeUndefined();
+  });
+});

--- a/tests/plugins/express/expected.data.yaml
+++ b/tests/plugins/express/expected.data.yaml
@@ -122,7 +122,7 @@ segmentItems:
 
 meterItems:
   - serviceName: server
-    meterSize: 6
+    meterSize: 12
     meters:
       - meterId:
           name: instance_nodejs_process_cpu
@@ -146,10 +146,34 @@ meterItems:
         singleValue: gt 0
       - meterId:
           name: instance_nodejs_external_memory
+          tags: []
+        singleValue: gt 0
+      - meterId:
+          name: instance_nodejs_array_buffers
+          tags: []
+        singleValue: ge 0
+      - meterId:
+          name: instance_nodejs_uptime
+          tags: []
+        singleValue: gt 0
+      - meterId:
+          name: instance_nodejs_peak_malloced_memory
+          tags: []
+        singleValue: gt 0
+      - meterId:
+          name: instance_nodejs_detached_contexts
+          tags: []
+        singleValue: ge 0
+      - meterId:
+          name: instance_nodejs_old_space_used
+          tags: []
+        singleValue: gt 0
+      - meterId:
+          name: instance_nodejs_new_space_used
           tags: []
         singleValue: gt 0
   - serviceName: client
-    meterSize: 6
+    meterSize: 12
     meters:
       - meterId:
           name: instance_nodejs_process_cpu
@@ -173,5 +197,29 @@ meterItems:
         singleValue: gt 0
       - meterId:
           name: instance_nodejs_external_memory
+          tags: []
+        singleValue: gt 0
+      - meterId:
+          name: instance_nodejs_array_buffers
+          tags: []
+        singleValue: ge 0
+      - meterId:
+          name: instance_nodejs_uptime
+          tags: []
+        singleValue: gt 0
+      - meterId:
+          name: instance_nodejs_peak_malloced_memory
+          tags: []
+        singleValue: gt 0
+      - meterId:
+          name: instance_nodejs_detached_contexts
+          tags: []
+        singleValue: ge 0
+      - meterId:
+          name: instance_nodejs_old_space_used
+          tags: []
+        singleValue: gt 0
+      - meterId:
+          name: instance_nodejs_new_space_used
           tags: []
         singleValue: gt 0

--- a/tests/remote-e2e/common/server.ts
+++ b/tests/remote-e2e/common/server.ts
@@ -1,0 +1,65 @@
+/*!
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import agent, { whenReady } from '../../../src';
+import * as http from 'http';
+
+void (async () => {
+  agent.start({ serviceName: 'server', maxBufferSize: 1000 });
+  await whenReady();
+
+  const server = http.createServer((req, res) => {
+    if (req.url === '/ping') {
+      res.statusCode = 200;
+      res.end('ok');
+      return;
+    }
+    if (req.url === '/flush') {
+      const deadlineMs = 8000;
+      let completed = false;
+      const timer = setTimeout(() => {
+        if (completed) {
+          return;
+        }
+        completed = true;
+        res.statusCode = 200;
+        res.end('flushed (deadline)');
+      }, deadlineMs);
+      void Promise.resolve(agent.flush())
+        .catch(() => undefined)
+        .finally(() => {
+          if (completed) {
+            return;
+          }
+          completed = true;
+          clearTimeout(timer);
+          res.statusCode = 200;
+          res.end('flushed');
+        });
+      return;
+    }
+    res.statusCode = 404;
+    res.end('not found');
+  });
+
+  server.listen(5000, () => console.info('Listening on port 5000...'));
+})().catch((error) => {
+  console.error('SkyWalking remote-e2e server failed to start:', error);
+  process.exit(1);
+});

--- a/tests/remote-e2e/dns-re-resolve/docker-compose.yml
+++ b/tests/remote-e2e/dns-re-resolve/docker-compose.yml
@@ -1,0 +1,83 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+version: '2.1'
+
+services:
+  collector-a:
+    image: ghcr.io/apache/skywalking-agent-test-tool/mock-collector:fa81b1b6d9caef484a65b5019efa28cac4e3d21d
+    ports:
+      - '12820:12800'
+    networks:
+      - traveling-light
+    healthcheck:
+      test: [ 'CMD', 'bash', '-c', 'cat < /dev/null > /dev/tcp/127.0.0.1/12800' ]
+      interval: 5s
+      timeout: 60s
+      retries: 120
+
+  collector-b:
+    image: ghcr.io/apache/skywalking-agent-test-tool/mock-collector:fa81b1b6d9caef484a65b5019efa28cac4e3d21d
+    ports:
+      - '12821:12800'
+    networks:
+      - traveling-light
+    healthcheck:
+      test: [ 'CMD', 'bash', '-c', 'cat < /dev/null > /dev/tcp/127.0.0.1/12800' ]
+      interval: 5s
+      timeout: 60s
+      retries: 120
+
+  server:
+    extends:
+      file: ../../plugins/common/base-compose.yml
+      service: agent
+    image: skywalking-nodejs-e2e-agent:22
+    build:
+      context: ../../../
+      dockerfile: tests/plugins/common/Dockerfile.agent
+      args:
+        SW_NODE_VERSION: "22"
+        NPM_REGISTRY: "https://registry.npmmirror.com"
+    ports:
+      - '5020:5000'
+    environment:
+      SW_AGENT_COLLECTOR_BACKEND_SERVICES: oap.test:19876
+      SW_AGENT_IS_RESOLVE_DNS_PERIODICALLY: 'true'
+      SW_AGENT_GRPC_CHANNEL_CHECK_INTERVAL: 1
+      SW_AGENT_FORCE_RECONNECTION_PERIOD: 1
+      SW_AGENT_RUNTIME_METRICS_REPORTER_ACTIVE: 'false'
+    volumes:
+      - ../../../src:/app/src
+      - ../common:/app/tests/remote-e2e/common
+      - .:/app/tests/remote-e2e/dns-re-resolve
+    entrypoint: [ 'bash', '/app/tests/remote-e2e/dns-re-resolve/entrypoint.sh' ]
+    depends_on:
+      collector-a:
+        condition: service_healthy
+      collector-b:
+        condition: service_healthy
+    healthcheck:
+      test: [ 'CMD', 'bash', '-c', 'cat < /dev/null > /dev/tcp/127.0.0.1/5000' ]
+      interval: 5s
+      timeout: 60s
+      retries: 120
+    networks:
+      - traveling-light
+
+networks:
+  traveling-light:

--- a/tests/remote-e2e/dns-re-resolve/entrypoint.sh
+++ b/tests/remote-e2e/dns-re-resolve/entrypoint.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+set -euo pipefail
+AIP="$(getent hosts collector-a | awk '{print $1; exit}')"
+BIP="$(getent hosts collector-b | awk '{print $1; exit}')"
+if [[ -z "${AIP}" || -z "${BIP}" ]]; then
+  echo "collector-a/collector-b IP not found for oap.test bootstrap" >&2
+  exit 1
+fi
+grep -v '[[:space:]]oap\.test' /etc/hosts > /tmp/hosts.oap || cp /etc/hosts /tmp/hosts.oap
+# Two A records for oap.test — Java expandBackendAddresses / getAllByName multi-IP parity.
+echo "${AIP} oap.test" >> /tmp/hosts.oap
+echo "${BIP} oap.test" >> /tmp/hosts.oap
+cat /tmp/hosts.oap > /etc/hosts
+exec npx ts-node /app/tests/remote-e2e/common/server.ts

--- a/tests/remote-e2e/dns-re-resolve/test.ts
+++ b/tests/remote-e2e/dns-re-resolve/test.ts
@@ -1,0 +1,60 @@
+/*!
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+/* eslint-env jest */
+
+import waitForExpect from 'wait-for-expect';
+import { StartedDockerComposeEnvironment } from 'testcontainers';
+import { createRemoteE2eContext, sleep } from '../support/helpers';
+
+const e2e = createRemoteE2eContext(__dirname, { serverPort: 5020, collectorBHttpPort: 12821 });
+
+describe('remote-e2e dns multi-ip failover (Phase B, Java selectedIdx parity)', () => {
+  let compose: StartedDockerComposeEnvironment | undefined;
+
+  beforeAll(async () => {
+    e2e.cleanupTestcontainers();
+    e2e.ensureE2eAgentImage();
+    compose = await e2e.upCompose();
+  }, 600000);
+
+  afterAll(async () => {
+    if (compose) {
+      await compose.down();
+    }
+  });
+
+  it('failovers via selectedIdx rotation after DNS expands hostname to multiple IPs', async () => {
+    if (!compose) {
+      throw new Error('Docker Compose environment failed to start');
+    }
+
+    await waitForExpect(async () => e2e.pingServer());
+    await sleep(10000);
+
+    await e2e.stopComposeService('collector-a');
+    await sleep(15000);
+
+    await waitForExpect(async () => e2e.pingServer());
+    await e2e.flushServer();
+    await sleep(5000);
+
+    await waitForExpect(async () => e2e.assertCollectorReceivedPing(), 120000, 3000);
+  }, 300000);
+});

--- a/tests/remote-e2e/static-failover/docker-compose.yml
+++ b/tests/remote-e2e/static-failover/docker-compose.yml
@@ -1,0 +1,82 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+version: '2.1'
+
+services:
+  collector-a:
+    image: ghcr.io/apache/skywalking-agent-test-tool/mock-collector:fa81b1b6d9caef484a65b5019efa28cac4e3d21d
+    ports:
+      - '12810:12800'
+    networks:
+      - traveling-light
+    healthcheck:
+      test: [ 'CMD', 'bash', '-c', 'cat < /dev/null > /dev/tcp/127.0.0.1/12800' ]
+      interval: 5s
+      timeout: 60s
+      retries: 120
+
+  collector-b:
+    image: ghcr.io/apache/skywalking-agent-test-tool/mock-collector:fa81b1b6d9caef484a65b5019efa28cac4e3d21d
+    ports:
+      - '12811:12800'
+    networks:
+      - traveling-light
+    healthcheck:
+      test: [ 'CMD', 'bash', '-c', 'cat < /dev/null > /dev/tcp/127.0.0.1/12800' ]
+      interval: 5s
+      timeout: 60s
+      retries: 120
+
+  server:
+    extends:
+      file: ../../plugins/common/base-compose.yml
+      service: agent
+    image: skywalking-nodejs-e2e-agent:22
+    build:
+      context: ../../../
+      dockerfile: tests/plugins/common/Dockerfile.agent
+      args:
+        SW_NODE_VERSION: "22"
+        NPM_REGISTRY: "https://registry.npmmirror.com"
+    ports:
+      - '5010:5000'
+    environment:
+      SW_AGENT_COLLECTOR_BACKEND_SERVICES: collector-a:19876,collector-b:19876
+      SW_AGENT_GRPC_CHANNEL_CHECK_INTERVAL: 2
+      SW_AGENT_FORCE_RECONNECTION_PERIOD: 1
+      SW_AGENT_RUNTIME_METRICS_REPORTER_ACTIVE: 'false'
+    volumes:
+      - ../../../src:/app/src
+      - ../common:/app/tests/remote-e2e/common
+      - .:/app/tests/remote-e2e/static-failover
+    entrypoint: [ 'bash', '-c', 'npx ts-node /app/tests/remote-e2e/common/server.ts' ]
+    depends_on:
+      collector-a:
+        condition: service_healthy
+      collector-b:
+        condition: service_healthy
+    healthcheck:
+      test: [ 'CMD', 'bash', '-c', 'cat < /dev/null > /dev/tcp/127.0.0.1/5000' ]
+      interval: 5s
+      timeout: 60s
+      retries: 120
+    networks:
+      - traveling-light
+
+networks:
+  traveling-light:

--- a/tests/remote-e2e/static-failover/test.ts
+++ b/tests/remote-e2e/static-failover/test.ts
@@ -1,0 +1,60 @@
+/*!
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+/* eslint-env jest */
+
+import waitForExpect from 'wait-for-expect';
+import { StartedDockerComposeEnvironment } from 'testcontainers';
+import { createRemoteE2eContext, sleep } from '../support/helpers';
+
+const e2e = createRemoteE2eContext(__dirname, { serverPort: 5010, collectorBHttpPort: 12811 });
+
+describe('remote-e2e static failover (Phase A)', () => {
+  let compose: StartedDockerComposeEnvironment | undefined;
+
+  beforeAll(async () => {
+    e2e.cleanupTestcontainers();
+    e2e.ensureE2eAgentImage();
+    compose = await e2e.upCompose();
+  });
+
+  afterAll(async () => {
+    if (compose) {
+      await compose.down();
+    }
+  });
+
+  it('reports to secondary collector after primary stops', async () => {
+    if (!compose) {
+      throw new Error('Docker Compose environment failed to start');
+    }
+
+    await waitForExpect(async () => e2e.pingServer());
+    await sleep(10000);
+
+    await e2e.stopComposeService('collector-a');
+    await sleep(15000);
+
+    await waitForExpect(async () => e2e.pingServer());
+    await e2e.flushServer();
+    await sleep(5000);
+
+    await waitForExpect(async () => e2e.assertCollectorReceivedPing(), 120000, 3000);
+  }, 300000);
+});

--- a/tests/remote-e2e/support/helpers.ts
+++ b/tests/remote-e2e/support/helpers.ts
@@ -1,0 +1,115 @@
+/*!
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+/* eslint-env jest */
+
+import * as path from 'path';
+import { execSync } from 'child_process';
+import { DockerComposeEnvironment, StartedDockerComposeEnvironment, Wait } from 'testcontainers';
+import axios from 'axios';
+
+export const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+export type RemoteE2ePorts = {
+  serverPort: number;
+  collectorBHttpPort: number;
+};
+
+export function createRemoteE2eContext(caseDir: string, ports: RemoteE2ePorts) {
+  const rootDir = path.resolve(caseDir);
+  const repoRoot = path.resolve(caseDir, '../../..');
+  const { serverPort, collectorBHttpPort } = ports;
+
+  function ensureE2eAgentImage(): void {
+    const nodeVersion = process.env.SW_NODE_VERSION || '22';
+    const tag = `skywalking-nodejs-e2e-agent:${nodeVersion}`;
+    const forceRebuild = process.env.GITHUB_ACTIONS === 'true' || process.env.CI === 'true';
+    if (!forceRebuild) {
+      try {
+        execSync(`docker image inspect ${tag}`, { stdio: 'pipe' });
+        return;
+      } catch {
+        // cold start — build once
+      }
+    }
+    const npmRegistry = process.env.E2E_NPM_REGISTRY || 'https://registry.npmmirror.com';
+    execSync(
+      [
+        'docker build -f tests/plugins/common/Dockerfile.agent',
+        `--build-arg SW_NODE_VERSION=${nodeVersion}`,
+        `--build-arg NPM_REGISTRY=${npmRegistry}`,
+        `-t ${tag}`,
+        '.',
+      ].join(' '),
+      { stdio: 'inherit', cwd: repoRoot, env: { ...process.env, DOCKER_BUILDKIT: '1' } },
+    );
+  }
+
+  function cleanupTestcontainers(): void {
+    try {
+      execSync('docker ps -aq --filter name=testcontainers | xargs -r docker rm -f', { stdio: 'pipe' });
+    } catch {
+      // best effort
+    }
+  }
+
+  async function pingServer(): Promise<void> {
+    const response = await axios.get(`http://localhost:${serverPort}/ping`);
+    expect(response.status).toBe(200);
+  }
+
+  async function flushServer(): Promise<void> {
+    const response = await axios.get(`http://localhost:${serverPort}/flush`);
+    expect(response.status).toBe(200);
+  }
+
+  async function assertCollectorReceivedPing(port: number = collectorBHttpPort): Promise<void> {
+    const data = String((await axios.get(`http://localhost:${port}/receiveData`)).data);
+    expect(data).toContain('serviceName: server');
+    expect(data).toContain('operationName: GET:/ping');
+    expect(data).toContain("http.status_code, value: '200'");
+  }
+
+  function stopComposeService(serviceName: string): void {
+    execSync(`docker ps --filter "name=${serviceName}" --format "{{.ID}}" | head -1 | xargs -r docker stop`, {
+      stdio: 'pipe',
+    });
+  }
+
+  async function upCompose(): Promise<StartedDockerComposeEnvironment> {
+    return new DockerComposeEnvironment(rootDir, 'docker-compose.yml')
+      .withWaitStrategy('collector-a', Wait.forHealthCheck())
+      .withWaitStrategy('collector-b', Wait.forHealthCheck())
+      .withWaitStrategy('server', Wait.forHealthCheck())
+      .up();
+  }
+
+  return {
+    rootDir,
+    ensureE2eAgentImage,
+    cleanupTestcontainers,
+    pingServer,
+    flushServer,
+    assertCollectorReceivedPing,
+    stopComposeService,
+    upCompose,
+  };
+}
+
+process.env.TESTCONTAINERS_RYUK_DISABLED = 'true';

--- a/tests/remote/AgentPackagePath.test.ts
+++ b/tests/remote/AgentPackagePath.test.ts
@@ -1,0 +1,51 @@
+/*!
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+/* eslint-env jest */
+
+import path from 'path';
+import {
+  getAgentPackagePath,
+  resolveAgentPath,
+  resetAgentPackagePathCacheForTest,
+} from '../../src/agent/core/boot/AgentPackagePath';
+
+describe('AgentPackagePath (Java AgentPackagePath parity)', () => {
+  afterEach(() => {
+    resetAgentPackagePathCacheForTest();
+  });
+
+  it('resolves agent package root from boot module location', () => {
+    const root = getAgentPackagePath();
+    expect(root).toBe(path.resolve(__dirname, '../..'));
+  });
+
+  it('joins relative paths under agent package root', () => {
+    const resolved = resolveAgentPath('ca/ca.crt');
+    expect(resolved).toBe(path.join(getAgentPackagePath(), 'ca/ca.crt'));
+  });
+
+  it('keeps absolute paths unchanged', () => {
+    expect(resolveAgentPath('/etc/ssl/ca.crt')).toBe('/etc/ssl/ca.crt');
+  });
+
+  it('rejects relative paths that escape the agent package root', () => {
+    expect(() => resolveAgentPath('../../../etc/passwd')).toThrow(/escapes agent package root/);
+  });
+});

--- a/tests/remote/AuthenticationDecorator.test.ts
+++ b/tests/remote/AuthenticationDecorator.test.ts
@@ -1,0 +1,79 @@
+/*!
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+/* eslint-env jest */
+
+import * as grpc from '@grpc/grpc-js';
+import config from '../../src/config/AgentConfig';
+import AuthenticationDecorator from '../../src/agent/core/remote/AuthenticationDecorator';
+
+function runStartHook(interceptor: grpc.Interceptor, metadata: grpc.Metadata): void {
+  const nextCall: grpc.NextCall = () =>
+    ({
+      start: () => {},
+      sendMessage: () => {},
+      halfClose: () => {},
+      cancel: () => {},
+      getPeer: () => 'test',
+    } as unknown as grpc.InterceptingCall);
+
+  const options = { method_definition: {} } as grpc.InterceptorOptions;
+  interceptor(options, nextCall).start(metadata);
+}
+
+describe('AuthenticationDecorator (Java AuthenticationDecorator parity)', () => {
+  const originalAuthorization = config.authorization;
+
+  afterEach(() => {
+    config.authorization = originalAuthorization;
+  });
+
+  it('adds Authentication header when SW_AGENT_AUTHENTICATION is configured', () => {
+    config.authorization = 'test-token';
+    const metadata = new grpc.Metadata();
+    const setSpy = jest.spyOn(metadata, 'set');
+
+    runStartHook(new AuthenticationDecorator().build(), metadata);
+
+    expect(setSpy).toHaveBeenCalledWith('Authentication', 'test-token');
+    setSpy.mockRestore();
+  });
+
+  it('does not add Authentication header when token is unset', () => {
+    config.authorization = undefined;
+    const metadata = new grpc.Metadata();
+    const setSpy = jest.spyOn(metadata, 'set');
+
+    runStartHook(new AuthenticationDecorator().build(), metadata);
+
+    expect(setSpy).not.toHaveBeenCalledWith('Authentication', expect.anything());
+    setSpy.mockRestore();
+  });
+
+  it('does not add Authentication header when token is empty', () => {
+    config.authorization = '';
+    const metadata = new grpc.Metadata();
+    const setSpy = jest.spyOn(metadata, 'set');
+
+    runStartHook(new AuthenticationDecorator().build(), metadata);
+
+    expect(setSpy).not.toHaveBeenCalledWith('Authentication', expect.anything());
+    setSpy.mockRestore();
+  });
+});

--- a/tests/remote/BackendAddressResolver.test.ts
+++ b/tests/remote/BackendAddressResolver.test.ts
@@ -1,0 +1,224 @@
+/*!
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+/* eslint-env jest */
+
+const mockLoggerError = jest.fn();
+const mockLoggerWarn = jest.fn();
+jest.mock('../../src/logging', () => ({
+  createLogger: jest.fn(() => ({
+    error: mockLoggerError,
+    debug: jest.fn(),
+    warn: mockLoggerWarn,
+    info: jest.fn(),
+  })),
+}));
+
+import {
+  countDistinctNonIpHostnames,
+  DnsLookupFn,
+  BackendTarget,
+  expandBackendAddresses,
+  deriveTlsServerNameForConnectHost,
+  formatHostPort,
+  isLiteralIp,
+  parseStaticBackendAddresses,
+  splitHostPort,
+  resetMultiHostnameTlsWarnForTest,
+  warnMultiHostnameTlsConstraint,
+} from '../../src/agent/core/remote/BackendAddressResolver';
+
+describe('BackendAddressResolver (Java InetAddress.getAllByName parity)', () => {
+  beforeEach(() => {
+    mockLoggerError.mockClear();
+  });
+
+  it('logs ERROR when DNS lookup fails (Java LOGGER.error)', async () => {
+    const lookup = jest.fn().mockRejectedValue(new Error('ENOTFOUND'));
+    await expandBackendAddresses(['missing.local:11800'], true, lookup);
+    expect(mockLoggerError).toHaveBeenCalledWith(
+      'Failed to resolve %s of backend service.',
+      'missing.local',
+      expect.any(Error),
+    );
+  });
+
+  it('parses comma-separated static backend addresses', () => {
+    expect(parseStaticBackendAddresses('127.0.0.1:11800, 10.0.0.2:11800')).toEqual([
+      '127.0.0.1:11800',
+      '10.0.0.2:11800',
+    ]);
+  });
+
+  it('filters invalid host:port entries', () => {
+    expect(parseStaticBackendAddresses('bad-entry,127.0.0.1:11800')).toEqual(['127.0.0.1:11800']);
+  });
+
+  it('parses bracketed IPv6 static backend addresses', () => {
+    expect(parseStaticBackendAddresses('[::1]:11800')).toEqual(['[::1]:11800']);
+    expect(splitHostPort('[::1]:11800')).toEqual({ host: '::1', port: '11800' });
+    expect(formatHostPort('::1', 11800)).toBe('[::1]:11800');
+  });
+
+  it('detects literal IP addresses', () => {
+    expect(isLiteralIp('127.0.0.1')).toBe(true);
+    expect(isLiteralIp('::1')).toBe(true);
+    expect(isLiteralIp('oap.local')).toBe(false);
+  });
+
+  it('returns static entries when DNS resolve is disabled', async () => {
+    const lookup = jest.fn();
+    const result = await expandBackendAddresses(['127.0.0.1:11800'], false, lookup);
+    expect(result).toEqual([{ target: '127.0.0.1:11800' }]);
+    expect(lookup).not.toHaveBeenCalled();
+  });
+
+  it('does not DNS lookup literal IP when resolveDns is true', async () => {
+    const lookup = jest.fn();
+    const result = await expandBackendAddresses(['127.0.0.1:11800'], true, lookup);
+    expect(result).toEqual([{ target: '127.0.0.1:11800' }]);
+    expect(lookup).not.toHaveBeenCalled();
+  });
+
+  it('expands hostname to multiple ip:port targets (Java getAllByName)', async () => {
+    const lookup = jest.fn().mockResolvedValue([
+      { address: '10.0.1.1', family: 4 },
+      { address: '10.0.1.2', family: 4 },
+    ]);
+    const result = await expandBackendAddresses(['fake-oap.local:11800'], true, lookup);
+    expect(lookup).toHaveBeenCalledWith('fake-oap.local', { all: true, verbatim: true });
+    expect(result).toEqual([
+      { target: '10.0.1.1:11800', tlsServerName: 'fake-oap.local' },
+      { target: '10.0.1.2:11800', tlsServerName: 'fake-oap.local' },
+    ]);
+  });
+
+  it('includes IPv6 addresses from DNS lookup', async () => {
+    const lookup = jest.fn().mockResolvedValue([{ address: '2001:db8::1', family: 6 }]);
+    const result = await expandBackendAddresses(['v6-host.local:11800'], true, lookup);
+    expect(result).toEqual([{ target: '[2001:db8::1]:11800', tlsServerName: 'v6-host.local' }]);
+  });
+
+  it('merges multiple comma-separated hostnames via DNS', async () => {
+    const lookup = jest
+      .fn()
+      .mockResolvedValueOnce([{ address: '10.0.1.1', family: 4 }])
+      .mockResolvedValueOnce([{ address: '10.0.1.2', family: 4 }]);
+    const result = await expandBackendAddresses(['a.local:11800', 'b.local:11800'], true, lookup);
+    expect(result).toEqual([
+      { target: '10.0.1.1:11800', tlsServerName: 'a.local' },
+      { target: '10.0.1.2:11800', tlsServerName: 'b.local' },
+    ]);
+  });
+
+  it('deduplicates identical ip:port from multiple hostnames (Java distinct)', async () => {
+    const lookup = jest
+      .fn()
+      .mockResolvedValueOnce([{ address: '10.0.1.1', family: 4 }])
+      .mockResolvedValueOnce([{ address: '10.0.1.1', family: 4 }]);
+    const result = await expandBackendAddresses(['a.local:11800', 'b.local:11800'], true, lookup);
+    expect(result).toEqual([{ target: '10.0.1.1:11800', tlsServerName: 'a.local' }]);
+  });
+
+  it('skips DNS lookup failures without throwing', async () => {
+    const lookup = jest.fn().mockRejectedValue(new Error('ENOTFOUND'));
+    const result = await expandBackendAddresses(['missing.local:11800'], true, lookup);
+    expect(result).toEqual([]);
+  });
+
+  it('returns partial results when one hostname fails and another succeeds', async () => {
+    const lookup = jest
+      .fn()
+      .mockRejectedValueOnce(new Error('ENOTFOUND'))
+      .mockResolvedValueOnce([{ address: '10.0.1.2', family: 4 }]);
+    const result = await expandBackendAddresses(['missing.local:11800', 'good.local:11800'], true, lookup);
+    expect(result).toEqual([{ target: '10.0.1.2:11800', tlsServerName: 'good.local' }]);
+  });
+
+  it('returns IPv6-only targets when DNS has no A records', async () => {
+    const lookup = jest.fn().mockResolvedValue([
+      { address: '2001:db8::a', family: 6 },
+      { address: '2001:db8::b', family: 6 },
+    ]);
+    const result = await expandBackendAddresses(['v6-only.local:11800'], true, lookup);
+    expect(result).toEqual([
+      { target: '[2001:db8::a]:11800', tlsServerName: 'v6-only.local' },
+      { target: '[2001:db8::b]:11800', tlsServerName: 'v6-only.local' },
+    ]);
+  });
+
+  it('caps DNS A record count (L4)', async () => {
+    const many = Array.from({ length: 100 }, (_, index) => ({
+      address: `10.0.${Math.floor(index / 256)}.${index % 256}`,
+      family: 4,
+    }));
+    const lookup = jest.fn().mockResolvedValue(many);
+    const result = await expandBackendAddresses(['big.local:11800'], true, lookup);
+    expect(result.length).toBe(64);
+    expect(result[0]?.tlsServerName).toBe('big.local');
+  });
+
+  it('times out slow DNS lookup without blocking (L4)', async () => {
+    jest.useFakeTimers();
+    const lookup: DnsLookupFn = jest.fn(() => new Promise(() => {}));
+    const promise = expandBackendAddresses(['slow.local:11800'], true, lookup);
+    await Promise.resolve();
+    jest.advanceTimersByTime(5_001);
+    await expect(promise).resolves.toEqual([]);
+    jest.useRealTimers();
+  });
+
+  it('derives TLS server name from collector hostname when connect host is IP', () => {
+    expect(deriveTlsServerNameForConnectHost('10.0.0.1', 'oap:11800')).toBe('oap');
+    expect(deriveTlsServerNameForConnectHost('10.0.0.1', 'oap:11800,backup:11800')).toBe('oap');
+  });
+
+  it('does not derive TLS server name when connect host is already a hostname', () => {
+    expect(deriveTlsServerNameForConnectHost('oap', 'oap:11800')).toBeUndefined();
+  });
+
+  it('does not derive TLS server name when collector address is IP-only', () => {
+    expect(deriveTlsServerNameForConnectHost('10.0.0.2', '127.0.0.1:11800')).toBeUndefined();
+  });
+  it('counts distinct non-IP hostnames in collectorAddress', () => {
+    expect(countDistinctNonIpHostnames('oap:11800')).toBe(1);
+    expect(countDistinctNonIpHostnames('oap:11800,backup:11800')).toBe(2);
+    expect(countDistinctNonIpHostnames('10.0.0.1:11800,10.0.0.2:11800')).toBe(0);
+  });
+
+  it('assigns per-hostname tlsServerName when multiple hostnames expand via DNS', async () => {
+    const lookup = jest
+      .fn()
+      .mockResolvedValueOnce([{ address: '10.0.1.1', family: 4 }])
+      .mockResolvedValueOnce([{ address: '10.0.1.2', family: 4 }]);
+    const result: BackendTarget[] = await expandBackendAddresses(['oap-a:11800', 'oap-b:11800'], true, lookup);
+    expect(result).toEqual([
+      { target: '10.0.1.1:11800', tlsServerName: 'oap-a' },
+      { target: '10.0.1.2:11800', tlsServerName: 'oap-b' },
+    ]);
+  });
+
+  it('warnMultiHostnameTlsConstraint is a no-op (per-target SNI supersedes H-2 doc constraint)', () => {
+    resetMultiHostnameTlsWarnForTest();
+    mockLoggerWarn.mockClear();
+    warnMultiHostnameTlsConstraint('oap-a:11800,oap-b:11800');
+    expect(mockLoggerWarn).not.toHaveBeenCalled();
+    resetMultiHostnameTlsWarnForTest();
+  });
+});

--- a/tests/remote/GRPCChannel.test.ts
+++ b/tests/remote/GRPCChannel.test.ts
@@ -1,0 +1,63 @@
+/*!
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+/* eslint-env jest */
+
+const channelTargets: string[] = [];
+
+jest.mock('@grpc/grpc-js', () => {
+  const actual = jest.requireActual('@grpc/grpc-js');
+  function Channel(this: { getConnectivityState: () => number; close: () => void }, target: string) {
+    channelTargets.push(target);
+    this.getConnectivityState = () => actual.connectivityState.IDLE;
+    this.close = jest.fn();
+  }
+  return { ...actual, Channel };
+});
+
+import GRPCChannel from '../../src/agent/core/remote/GRPCChannel';
+import StandardChannelBuilder from '../../src/agent/core/remote/StandardChannelBuilder';
+
+describe('GRPCChannel', () => {
+  beforeEach(() => {
+    channelTargets.length = 0;
+  });
+
+  it('uses bracketed IPv6 target for grpc-js Channel constructor', () => {
+    const channel = GRPCChannel.newBuilder('::1', 11800).addManagedChannelBuilder(new StandardChannelBuilder()).build();
+    expect(channelTargets).toEqual(['[::1]:11800']);
+    channel.shutdownNow();
+  });
+
+  it('uses plain host:port for IPv4 targets', () => {
+    const channel = GRPCChannel.newBuilder('127.0.0.1', 11800)
+      .addManagedChannelBuilder(new StandardChannelBuilder())
+      .build();
+    expect(channelTargets).toEqual(['127.0.0.1:11800']);
+    channel.shutdownNow();
+  });
+
+  it('uses bracketed IPv6 target for full IPv6 literals', () => {
+    const channel = GRPCChannel.newBuilder('2001:db8::1', 11800)
+      .addManagedChannelBuilder(new StandardChannelBuilder())
+      .build();
+    expect(channelTargets).toEqual(['[2001:db8::1]:11800']);
+    channel.shutdownNow();
+  });
+});

--- a/tests/remote/GRPCChannelManager.test.ts
+++ b/tests/remote/GRPCChannelManager.test.ts
@@ -20,12 +20,23 @@
 /* eslint-env jest */
 
 import * as grpc from '@grpc/grpc-js';
+import config from '../../src/config/AgentConfig';
+import * as resolver from '../../src/agent/core/remote/BackendAddressResolver';
 import GRPCChannelManager from '../../src/agent/core/remote/GRPCChannelManager';
 import { GRPCChannelStatus } from '../../src/agent/core/remote/GRPCChannelStatus';
+import GRPCChannel from '../../src/agent/core/remote/GRPCChannel';
 
 const mockShutdownNow = jest.fn();
-const mockGetConnectivityState = jest.fn();
-const mockWatchConnectivityState = jest.fn();
+const mockIsConnected = jest.fn((_force?: boolean) => true);
+const mockBuild = jest.fn(() => ({
+  getChannel: () => ({
+    getConnectivityState: jest.fn(() => grpc.connectivityState.READY),
+    watchConnectivityState: jest.fn(),
+  }),
+  getClientOptions: () => ({ channelOverride: { kind: 'mock-channel' }, interceptors: [] }),
+  isConnected: (force?: boolean) => mockIsConnected(force),
+  shutdownNow: mockShutdownNow,
+}));
 
 jest.mock('../../src/agent/core/remote/GRPCChannel', () => ({
   __esModule: true,
@@ -33,53 +44,422 @@ jest.mock('../../src/agent/core/remote/GRPCChannel', () => ({
     newBuilder: jest.fn(() => ({
       addManagedChannelBuilder: jest.fn().mockReturnThis(),
       addChannelDecorator: jest.fn().mockReturnThis(),
-      build: jest.fn(() => ({
-        getChannel: () => ({
-          getConnectivityState: mockGetConnectivityState,
-          watchConnectivityState: mockWatchConnectivityState,
-        }),
-        getClientOptions: () => ({ channelOverride: {} }),
-        isConnected: jest.fn(() => true),
-        shutdownNow: mockShutdownNow,
-      })),
+      build: mockBuild,
     })),
   },
 }));
 
-jest.mock('../../src/config/AgentConfig', () => ({
-  __esModule: true,
-  default: {
-    collectorAddress: '127.0.0.1:11800',
-  },
-}));
+describe('GRPCChannelManager (Java DNS re-resolve parity)', () => {
+  const originalCollector = config.collectorAddress;
+  const originalResolveDns = config.isResolveDnsPeriodically;
+  const originalCheckInterval = config.grpcChannelCheckInterval;
+  const originalForcePeriod = config.forceReconnectionPeriod;
+  let manager: GRPCChannelManager | null = null;
+  let randomSpy: jest.SpyInstance;
 
-describe('GRPCChannelManager initial connectivity', () => {
   beforeEach(() => {
-    jest.clearAllMocks();
-    mockWatchConnectivityState.mockImplementation(() => undefined);
+    mockShutdownNow.mockClear();
+    mockIsConnected.mockReset();
+    mockIsConnected.mockImplementation((_force?: boolean) => true);
+    randomSpy = jest.spyOn(Math, 'random');
   });
 
-  it('notifies CONNECTED when channel is already READY at boot', () => {
-    mockGetConnectivityState.mockReturnValue(grpc.connectivityState.READY);
-
-    const listener = { statusChanged: jest.fn() };
-    const manager = new GRPCChannelManager();
-
-    manager.addChannelListener(listener);
-    manager.boot();
-
-    expect(listener.statusChanged).toHaveBeenCalledWith(GRPCChannelStatus.CONNECTED);
+  afterEach(() => {
+    jest.useRealTimers();
+    manager?.shutdown();
+    manager = null;
+    config.collectorAddress = originalCollector;
+    config.isResolveDnsPeriodically = originalResolveDns;
+    config.grpcChannelCheckInterval = originalCheckInterval;
+    config.forceReconnectionPeriod = originalForcePeriod;
+    randomSpy.mockRestore();
+    jest.restoreAllMocks();
   });
 
-  it('notifies DISCONNECT when channel is not READY at boot', () => {
-    mockGetConnectivityState.mockReturnValue(grpc.connectivityState.CONNECTING);
+  it('returns logical hostname for stub when channel uses resolved IP', async () => {
+    config.collectorAddress = 'oap:11800';
+    config.isResolveDnsPeriodically = true;
+    randomSpy.mockReturnValue(0);
+    jest
+      .spyOn(resolver, 'expandBackendAddresses')
+      .mockResolvedValue([{ target: '10.0.1.1:11800', tlsServerName: 'oap' }]);
 
-    const listener = { statusChanged: jest.fn() };
-    const manager = new GRPCChannelManager();
+    manager = new GRPCChannelManager();
+    await manager.runCheck();
 
-    manager.addChannelListener(listener);
+    expect(manager.getGrpcServersForTest()).toEqual([{ target: '10.0.1.1:11800', tlsServerName: 'oap' }]);
+    expect(manager.resolveAddress()).toBe('oap:11800');
+  });
+  it('resolveAddress returns current target after runCheck selects backend', async () => {
+    config.collectorAddress = '127.0.0.1:11800';
+    config.isResolveDnsPeriodically = false;
+    randomSpy.mockReturnValue(0);
+
+    manager = new GRPCChannelManager();
+    await manager.runCheck();
+
+    expect(manager.resolveAddress()).toBe('127.0.0.1:11800');
+    expect(manager.getSelectedIdxForTest()).toBe(0);
+    expect(manager.getReconnectStateForTest()).toBe(false);
+  });
+
+  it('does not call DNS expand when isResolveDnsPeriodically is false', async () => {
+    config.collectorAddress = 'fake-oap.local:11800';
+    config.isResolveDnsPeriodically = false;
+    const expandSpy = jest.spyOn(resolver, 'expandBackendAddresses');
+
+    manager = new GRPCChannelManager();
+    await manager.runCheck();
+
+    expect(expandSpy).not.toHaveBeenCalled();
+    expect(manager.getGrpcServersForTest()).toEqual([{ target: 'fake-oap.local:11800' }]);
+  });
+
+  it('does not call DNS expand when reconnect is false (Java IS_RESOLVE_DNS && reconnect)', async () => {
+    config.collectorAddress = 'fake-oap.local:11800';
+    config.isResolveDnsPeriodically = true;
+    randomSpy.mockReturnValue(0);
+
+    const expandSpy = jest
+      .spyOn(resolver, 'expandBackendAddresses')
+      .mockResolvedValue([{ target: '10.0.1.1:11800', tlsServerName: 'oap' }]);
+
+    manager = new GRPCChannelManager();
+    await manager.runCheck();
+    expect(expandSpy).toHaveBeenCalledTimes(1);
+
+    expandSpy.mockClear();
+    await manager.runCheck();
+    expect(expandSpy).not.toHaveBeenCalled();
+  });
+
+  it('runCheck refreshes grpcServers from DNS when reconnect is true', async () => {
+    config.collectorAddress = 'fake-oap.local:11800';
+    config.isResolveDnsPeriodically = true;
+    randomSpy.mockReturnValue(0);
+
+    jest
+      .spyOn(resolver, 'expandBackendAddresses')
+      .mockResolvedValue([{ target: '10.0.1.1:11800' }, { target: '10.0.1.2:11800' }]);
+
+    manager = new GRPCChannelManager();
+    manager.reportError({ code: grpc.status.UNAVAILABLE, message: 'fail' } as grpc.ServiceError);
+    await manager.runCheck();
+
+    expect(resolver.expandBackendAddresses).toHaveBeenCalledWith(['fake-oap.local:11800'], true);
+    expect(manager.getGrpcServersForTest()).toEqual([{ target: '10.0.1.1:11800' }, { target: '10.0.1.2:11800' }]);
+  });
+
+  it('uses static comma-separated backends without DNS (Java split comma)', async () => {
+    config.collectorAddress = '127.0.0.1:11800,10.0.0.2:11800';
+    config.isResolveDnsPeriodically = false;
+    randomSpy.mockReturnValue(0.99);
+
+    manager = new GRPCChannelManager();
+    await manager.runCheck();
+
+    expect(manager.getGrpcServersForTest()).toEqual([{ target: '127.0.0.1:11800' }, { target: '10.0.0.2:11800' }]);
+    expect(manager.resolveAddress()).toBe('10.0.0.2:11800');
+  });
+
+  it('reportError sets reconnect on gRPC network errors', () => {
+    config.collectorAddress = '127.0.0.1:11800';
+    manager = new GRPCChannelManager();
+
+    manager.reportError({ code: grpc.status.UNAVAILABLE, message: 'fail' } as grpc.ServiceError);
+    expect(manager.getReconnectStateForTest()).toBe(true);
+  });
+
+  it('reportError ignores non-network gRPC errors', async () => {
+    config.collectorAddress = '127.0.0.1:11800';
+    randomSpy.mockReturnValue(0);
+    manager = new GRPCChannelManager();
+    await manager.runCheck();
+    expect(manager.getReconnectStateForTest()).toBe(false);
+
+    const listener = jest.fn();
+    manager.addChannelListener({ statusChanged: listener });
+
+    manager.reportError({ code: grpc.status.INVALID_ARGUMENT, message: 'bad' } as grpc.ServiceError);
+    expect(manager.getReconnectStateForTest()).toBe(false);
+    expect(listener).not.toHaveBeenCalledWith(GRPCChannelStatus.DISCONNECT);
+  });
+
+  it('reportError does not reconnect on authentication failures (B-3)', async () => {
+    config.collectorAddress = '127.0.0.1:11800';
+    randomSpy.mockReturnValue(0);
+    manager = new GRPCChannelManager();
+    await manager.runCheck();
+    expect(manager.getReconnectStateForTest()).toBe(false);
+
+    const listener = jest.fn();
+    manager.addChannelListener({ statusChanged: listener });
+
+    manager.reportError({ code: grpc.status.PERMISSION_DENIED, message: 'denied' } as grpc.ServiceError);
+    expect(manager.getReconnectStateForTest()).toBe(false);
+    expect(listener).not.toHaveBeenCalledWith(GRPCChannelStatus.DISCONNECT);
+
+    manager.reportError({ code: grpc.status.UNAUTHENTICATED, message: 'bad token' } as grpc.ServiceError);
+    expect(manager.getReconnectStateForTest()).toBe(false);
+  });
+
+  it('reportError notifies DISCONNECT to listeners (Java notify DISCONNECT)', () => {
+    config.collectorAddress = '127.0.0.1:11800';
+    manager = new GRPCChannelManager();
+    const listener = jest.fn();
+    manager.addChannelListener({ statusChanged: listener });
+
+    manager.reportError({ code: grpc.status.UNAVAILABLE, message: 'fail' } as grpc.ServiceError);
+
+    expect(listener).toHaveBeenCalledWith(GRPCChannelStatus.DISCONNECT);
+    expect(manager.getLastStatusForTest()).toBe(GRPCChannelStatus.DISCONNECT);
+  });
+
+  it('keeps channel when DNS ip changes at same index (Java GRPCChannelManager parity)', async () => {
+    config.collectorAddress = 'oap.test:11800';
+    config.isResolveDnsPeriodically = true;
+    config.forceReconnectionPeriod = 1;
+    randomSpy.mockReturnValue(0);
+
+    jest
+      .spyOn(resolver, 'expandBackendAddresses')
+      .mockResolvedValueOnce([{ target: '10.0.1.1:11800' }])
+      .mockResolvedValueOnce([{ target: '10.0.1.2:11800' }]);
+
+    manager = new GRPCChannelManager();
+    await manager.runCheck();
+    expect(manager.resolveAddress()).toBe('oap.test:11800');
+    expect(mockShutdownNow).not.toHaveBeenCalled();
+
+    manager.reportError({ code: grpc.status.UNAVAILABLE, message: 'fail' } as grpc.ServiceError);
+    mockIsConnected.mockReturnValue(true);
+    await manager.runCheck();
+
+    expect(manager.resolveAddress()).toBe('oap.test:11800');
+    expect(mockShutdownNow).not.toHaveBeenCalled();
+    expect(manager.getSelectedIdxForTest()).toBe(0);
+  });
+
+  it('switches channel when random index changes (Java selectedIdx rotation)', async () => {
+    config.collectorAddress = '127.0.0.1:11800,10.0.0.2:11800';
+    config.isResolveDnsPeriodically = false;
+
+    manager = new GRPCChannelManager();
+    randomSpy.mockReturnValue(0);
+    await manager.runCheck();
+    expect(manager.getSelectedIdxForTest()).toBe(0);
+    expect(mockShutdownNow).not.toHaveBeenCalled();
+
+    manager.reportError({ code: grpc.status.UNAVAILABLE, message: 'fail' } as grpc.ServiceError);
+    randomSpy.mockReturnValue(0.99);
+    await manager.runCheck();
+
+    expect(manager.getSelectedIdxForTest()).toBe(1);
+    expect(mockShutdownNow).toHaveBeenCalledTimes(1);
+    expect(manager.resolveAddress()).toBe('10.0.0.2:11800');
+  });
+
+  it('clears reconnect on same index when forceReconnectionPeriod exceeded (Java FORCE_RECONNECTION_PERIOD)', async () => {
+    config.collectorAddress = '127.0.0.1:11800';
+    config.isResolveDnsPeriodically = false;
+    config.forceReconnectionPeriod = 1;
+    randomSpy.mockReturnValue(0);
+
+    manager = new GRPCChannelManager();
+    await manager.runCheck();
+    expect(manager.getReconnectStateForTest()).toBe(false);
+
+    manager.reportError({ code: grpc.status.UNAVAILABLE, message: 'fail' } as grpc.ServiceError);
+    mockIsConnected.mockImplementation((force?: boolean) => force === true);
+
+    await manager.runCheck();
+    expect(manager.getReconnectCountForTest()).toBe(1);
+    expect(manager.getReconnectStateForTest()).toBe(true);
+
+    await manager.runCheck();
+    expect(manager.getReconnectStateForTest()).toBe(false);
+    expect(manager.getReconnectCountForTest()).toBe(0);
+  });
+
+  it('keeps reconnect when DNS returns empty list', async () => {
+    config.collectorAddress = 'missing.local:11800';
+    config.isResolveDnsPeriodically = true;
+
+    jest.spyOn(resolver, 'expandBackendAddresses').mockResolvedValue([]);
+
+    manager = new GRPCChannelManager();
+    await manager.runCheck();
+
+    expect(manager.getGrpcServersForTest()).toEqual([]);
+    expect(manager.getReconnectStateForTest()).toBe(true);
+  });
+
+  it('recovers after DNS returns empty then later returns backends', async () => {
+    config.collectorAddress = 'oap.test:11800';
+    config.isResolveDnsPeriodically = true;
+    randomSpy.mockReturnValue(0);
+
+    jest
+      .spyOn(resolver, 'expandBackendAddresses')
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([{ target: '10.0.1.1:11800' }]);
+
+    manager = new GRPCChannelManager();
+    await manager.runCheck();
+    expect(manager.getGrpcServersForTest()).toEqual([]);
+    expect(manager.getReconnectStateForTest()).toBe(true);
+
+    await manager.runCheck();
+    expect(manager.resolveAddress()).toBe('oap.test:11800');
+    expect(manager.getReconnectStateForTest()).toBe(false);
+  });
+
+  it('rotates to next backend when same random index is unreachable', async () => {
+    config.collectorAddress = '127.0.0.1:11800,10.0.0.2:11800';
+    config.isResolveDnsPeriodically = false;
+    config.forceReconnectionPeriod = 1;
+    randomSpy.mockReturnValue(0);
+
+    manager = new GRPCChannelManager();
+    await manager.runCheck();
+    expect(manager.getSelectedIdxForTest()).toBe(0);
+
+    manager.reportError({ code: grpc.status.UNAVAILABLE, message: 'fail' } as grpc.ServiceError);
+    mockIsConnected.mockReturnValue(false);
+    await manager.runCheck();
+
+    expect(manager.getSelectedIdxForTest()).toBe(1);
+    expect(mockShutdownNow).toHaveBeenCalledTimes(1);
+    expect(manager.resolveAddress()).toBe('10.0.0.2:11800');
+  });
+
+  it('rotates among multiple DNS-expanded IPs on reconnect', async () => {
+    config.collectorAddress = 'oap.test:11800';
+    config.isResolveDnsPeriodically = true;
+
+    jest
+      .spyOn(resolver, 'expandBackendAddresses')
+      .mockResolvedValue([{ target: '10.0.1.1:11800' }, { target: '10.0.1.2:11800' }]);
+
+    manager = new GRPCChannelManager();
+    randomSpy.mockReturnValue(0);
+    await manager.runCheck();
+    expect(manager.resolveAddress()).toBe('oap.test:11800');
+
+    manager.reportError({ code: grpc.status.UNAVAILABLE, message: 'fail' } as grpc.ServiceError);
+    randomSpy.mockReturnValue(0.99);
+    await manager.runCheck();
+    expect(manager.resolveAddress()).toBe('oap.test:11800');
+  });
+
+  it('boot starts periodic check timer (Java GRPC_CHANNEL_CHECK_INTERVAL)', () => {
+    jest.useFakeTimers();
+    config.collectorAddress = '127.0.0.1:11800';
+    config.grpcChannelCheckInterval = 5;
+    randomSpy.mockReturnValue(0);
+
+    manager = new GRPCChannelManager();
     manager.boot();
 
-    expect(listener.statusChanged).toHaveBeenCalledWith(GRPCChannelStatus.DISCONNECT);
+    expect(manager.hasCheckTimerForTest()).toBe(true);
+    jest.advanceTimersByTime(5000);
+  });
+
+  it('boot skips timer when collector address is empty', () => {
+    config.collectorAddress = '';
+    manager = new GRPCChannelManager();
+    manager.boot();
+    expect(manager.hasCheckTimerForTest()).toBe(false);
+  });
+
+  it('shutdown clears check timer', () => {
+    jest.useFakeTimers();
+    config.collectorAddress = '127.0.0.1:11800';
+    manager = new GRPCChannelManager();
+    manager.boot();
+    expect(manager.hasCheckTimerForTest()).toBe(true);
+    manager.shutdown();
+    expect(manager.hasCheckTimerForTest()).toBe(false);
+  });
+
+  describe('shutdown late async continuation safety (H2)', () => {
+    it('does not build a channel when shutdown completes during DNS expand', async () => {
+      config.collectorAddress = 'fake-oap.local:11800';
+      config.isResolveDnsPeriodically = true;
+      randomSpy.mockReturnValue(0);
+      mockBuild.mockClear();
+      (GRPCChannel.newBuilder as jest.Mock).mockClear();
+
+      let resolveExpand!: (value: resolver.BackendTarget[]) => void;
+      const expandPromise = new Promise<resolver.BackendTarget[]>((resolve) => {
+        resolveExpand = resolve;
+      });
+      jest.spyOn(resolver, 'expandBackendAddresses').mockReturnValue(expandPromise);
+
+      const listener = jest.fn();
+      manager = new GRPCChannelManager();
+      manager.addChannelListener({ statusChanged: listener });
+      const runPromise = manager.runCheck();
+
+      manager.shutdown();
+      resolveExpand([{ target: '10.0.1.1:11800' }]);
+      await runPromise;
+
+      expect(mockBuild).not.toHaveBeenCalled();
+      expect(GRPCChannel.newBuilder).not.toHaveBeenCalled();
+      expect(listener).not.toHaveBeenCalledWith(GRPCChannelStatus.CONNECTED);
+    });
+  });
+  it('resolveAddress brackets IPv6 literal targets for grpc client stubs', async () => {
+    config.collectorAddress = '[::1]:11800';
+    randomSpy.mockReturnValue(0);
+    const newBuilderSpy = GRPCChannel.newBuilder as jest.Mock;
+
+    manager = new GRPCChannelManager();
+    await manager.runCheck();
+
+    expect(newBuilderSpy).toHaveBeenCalledWith('::1', 11800, undefined);
+    expect(manager.resolveAddress()).toBe('[::1]:11800');
+  });
+
+  it('getClientOptions exposes channelOverride from managed channel (S-1)', async () => {
+    config.collectorAddress = '127.0.0.1:11800';
+    randomSpy.mockReturnValue(0);
+
+    manager = new GRPCChannelManager();
+    await manager.runCheck();
+
+    const opts = manager.getClientOptions();
+    expect(opts.channelOverride).toEqual({ kind: 'mock-channel' });
+    expect(opts.interceptors).toEqual([]);
+  });
+
+  it('passes per-target tlsServerName to GRPCChannel.newBuilder', async () => {
+    config.collectorAddress = 'oap:11800';
+    config.isResolveDnsPeriodically = true;
+    randomSpy.mockReturnValue(0);
+    jest
+      .spyOn(resolver, 'expandBackendAddresses')
+      .mockResolvedValue([{ target: '10.0.1.1:11800', tlsServerName: 'oap' }]);
+    const newBuilderSpy = GRPCChannel.newBuilder as jest.Mock;
+
+    manager = new GRPCChannelManager();
+    await manager.runCheck();
+
+    expect(newBuilderSpy).toHaveBeenCalledWith('10.0.1.1', 11800, 'oap');
+  });
+
+  it('resolveAddress keeps hostname for DNS-expanded IPv6 (TLS SNI)', async () => {
+    config.collectorAddress = 'oap.test:11800';
+    config.isResolveDnsPeriodically = true;
+    randomSpy.mockReturnValue(0);
+    jest
+      .spyOn(resolver, 'expandBackendAddresses')
+      .mockResolvedValue([{ target: '[2001:db8::1]:11800', tlsServerName: 'oap.test' }]);
+
+    manager = new GRPCChannelManager();
+    await manager.runCheck();
+
+    expect(manager.resolveAddress()).toBe('oap.test:11800');
   });
 });

--- a/tests/remote/GrpcUpstreamOptions.test.ts
+++ b/tests/remote/GrpcUpstreamOptions.test.ts
@@ -1,0 +1,56 @@
+/*!
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+/* eslint-env jest */
+
+describe('grpcUpstreamDeadlineMs (Java GRPC_UPSTREAM_TIMEOUT parity)', () => {
+  const envBackup = { ...process.env };
+
+  afterEach(() => {
+    process.env = { ...envBackup };
+    jest.resetModules();
+  });
+
+  it('defaults to 30 seconds when unset', () => {
+    delete process.env.SW_AGENT_COLLECTOR_GRPC_UPSTREAM_TIMEOUT;
+    delete process.env.SW_AGENT_TRACE_TIMEOUT;
+    jest.resetModules();
+    const { grpcUpstreamDeadlineMs } = require('../../src/agent/core/remote/GrpcUpstreamOptions');
+    const before = Date.now();
+    expect(grpcUpstreamDeadlineMs()).toBeGreaterThanOrEqual(before + 30_000);
+    expect(grpcUpstreamDeadlineMs()).toBeLessThanOrEqual(before + 30_000 + 50);
+  });
+
+  it('reads SW_AGENT_COLLECTOR_GRPC_UPSTREAM_TIMEOUT in seconds', () => {
+    process.env.SW_AGENT_COLLECTOR_GRPC_UPSTREAM_TIMEOUT = '45';
+    jest.resetModules();
+    const { grpcUpstreamDeadlineMs } = require('../../src/agent/core/remote/GrpcUpstreamOptions');
+    const before = Date.now();
+    expect(grpcUpstreamDeadlineMs()).toBeGreaterThanOrEqual(before + 45_000);
+  });
+
+  it('falls back to SW_AGENT_TRACE_TIMEOUT milliseconds when collector timeout unset', () => {
+    delete process.env.SW_AGENT_COLLECTOR_GRPC_UPSTREAM_TIMEOUT;
+    process.env.SW_AGENT_TRACE_TIMEOUT = '12000';
+    jest.resetModules();
+    const { grpcUpstreamDeadlineMs } = require('../../src/agent/core/remote/GrpcUpstreamOptions');
+    const before = Date.now();
+    expect(grpcUpstreamDeadlineMs()).toBeGreaterThanOrEqual(before + 12_000);
+  });
+});

--- a/tests/remote/MeterSender.test.ts
+++ b/tests/remote/MeterSender.test.ts
@@ -1,0 +1,283 @@
+/*!
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+/* eslint-env jest */
+
+import { GRPCChannelStatus } from '../../src/agent/core/remote/GRPCChannelStatus';
+
+const mockCollect = jest.fn();
+const mockGrpcUpstreamDeadlineMs = jest.fn(() => 5_432_109_876);
+let pendingCollectCallback: ((error: Error | null) => void) | undefined;
+
+const mockChannelManager = {
+  addChannelListener: jest.fn(),
+  resolveAddress: jest.fn(() => '127.0.0.1:11800'),
+  getClientOptions: jest.fn(() => ({ channelOverride: {} as never })),
+  reportError: jest.fn(),
+};
+
+const mockMeterData = {
+  setService: jest.fn().mockReturnThis(),
+  setServiceinstance: jest.fn().mockReturnThis(),
+  setTimestamp: jest.fn().mockReturnThis(),
+};
+
+const mockStream = {
+  write: jest.fn(),
+  end: jest.fn(),
+};
+
+let sampleSequence = 0;
+const mockSnapshot = () => ({ collectedAt: 1_000_000 + sampleSequence++ * 500, cpu: 1 });
+
+jest.mock('../../src/config/AgentConfig', () => ({
+  __esModule: true,
+  default: {
+    serviceName: 'meter-service',
+    serviceInstance: 'meter-instance',
+    runtimeMetricsCollectPeriod: 1000,
+    runtimeMetricsReportPeriod: 1000,
+    runtimeMetricsBufferSize: 600,
+  },
+}));
+
+jest.mock('../../src/proto/language-agent/Meter_grpc_pb', () => ({
+  MeterReportServiceClient: jest.fn().mockImplementation(() => ({
+    collect: jest.fn((_meta, opts, cb) => {
+      pendingCollectCallback = cb;
+      return mockCollect(_meta, opts, cb);
+    }),
+  })),
+}));
+
+jest.mock('../../src/agent/core/meter/RuntimeMetricsCollector', () => {
+  return jest.fn().mockImplementation(() => ({
+    sample: jest.fn(() => mockSnapshot()),
+    toMeterData: jest.fn(() => [mockMeterData, { ...mockMeterData }]),
+    destroy: jest.fn(),
+  }));
+});
+
+jest.mock('../../src/agent/core/remote/GrpcUpstreamOptions', () => ({
+  grpcUpstreamDeadlineMs: () => mockGrpcUpstreamDeadlineMs(),
+}));
+
+jest.mock('../../src/agent/core/boot/ServiceManager', () => ({
+  __esModule: true,
+  default: {
+    INSTANCE: {
+      findService: jest.fn((serviceClass: { name?: string }) => {
+        if (serviceClass?.name === 'CommandService') {
+          return { receiveCommand: jest.fn() };
+        }
+        return mockChannelManager;
+      }),
+    },
+  },
+}));
+
+jest.mock('../../src/logging', () => ({
+  createLogger: () => ({
+    warn: jest.fn(),
+    info: jest.fn(),
+    error: jest.fn(),
+    _isDebugEnabled: false,
+  }),
+  throttled: () => jest.fn(),
+}));
+
+import * as grpc from '@grpc/grpc-js';
+import MeterSender from '../../src/agent/core/meter/MeterSender';
+import { MeterReportServiceClient } from '../../src/proto/language-agent/Meter_grpc_pb';
+
+describe('MeterSender', () => {
+  let sender: MeterSender;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    mockCollect.mockClear();
+    mockGrpcUpstreamDeadlineMs.mockClear();
+    mockChannelManager.reportError.mockClear();
+    mockMeterData.setService.mockClear();
+    mockMeterData.setServiceinstance.mockClear();
+    mockMeterData.setTimestamp.mockClear();
+    mockStream.write.mockReset();
+    mockStream.end.mockReset();
+    pendingCollectCallback = undefined;
+    mockCollect.mockImplementation((_meta, _opts, cb) => {
+      pendingCollectCallback = cb;
+      return mockStream;
+    });
+    sender = new MeterSender();
+    sender.prepare();
+    sender.statusChanged(GRPCChannelStatus.CONNECTED);
+    sender.boot();
+  });
+
+  afterEach(() => {
+    sender.shutdown();
+    jest.useRealTimers();
+  });
+
+  it('clears reporter stub on DISCONNECT', () => {
+    sender.statusChanged(GRPCChannelStatus.DISCONNECT);
+    expect(MeterReportServiceClient).toHaveBeenCalledTimes(1);
+  });
+
+  it('uses per-snapshot collectedAt timestamps (Java JVMService parity)', async () => {
+    const senderAny = sender as unknown as { buffer: Array<{ collectedAt: number }> };
+    senderAny.buffer.push({ collectedAt: 1_000_000, cpu: 1 } as never, { collectedAt: 2_000_000, cpu: 1 } as never);
+
+    jest.advanceTimersByTime(1_000);
+    await Promise.resolve();
+
+    const firstBatch = mockMeterData.setTimestamp.mock.calls.map((call) => call[0]);
+    expect(firstBatch).toContain(1_000_000);
+    expect(firstBatch).not.toContain(2_000_000);
+    pendingCollectCallback?.(null);
+    await Promise.resolve();
+
+    mockMeterData.setTimestamp.mockClear();
+    jest.advanceTimersByTime(1_000);
+    await Promise.resolve();
+
+    const secondBatch = mockMeterData.setTimestamp.mock.calls.map((call) => call[0]);
+    expect(secondBatch).toContain(2_000_000);
+  });
+
+  it('sets service/instance/timestamp on every MeterData', async () => {
+    jest.advanceTimersByTime(1_000);
+    await Promise.resolve();
+    jest.advanceTimersByTime(1_000);
+    await Promise.resolve();
+
+    expect(mockMeterData.setService).toHaveBeenCalledWith('meter-service');
+    expect(mockMeterData.setServiceinstance).toHaveBeenCalledWith('meter-instance');
+    expect(mockMeterData.setService).toHaveBeenCalledTimes(2);
+    expect(mockMeterData.setServiceinstance).toHaveBeenCalledTimes(2);
+    expect(mockMeterData.setTimestamp).toHaveBeenCalledTimes(2);
+  });
+
+  it('skips duplicate boot timers', () => {
+    const collectTimer = (sender as unknown as { collectTimer?: NodeJS.Timeout }).collectTimer;
+    const reportTimer = (sender as unknown as { reportTimer?: NodeJS.Timeout }).reportTimer;
+    sender.boot();
+    expect((sender as unknown as { collectTimer?: NodeJS.Timeout }).collectTimer).toBe(collectTimer);
+    expect((sender as unknown as { reportTimer?: NodeJS.Timeout }).reportTimer).toBe(reportTimer);
+  });
+
+  it('re-queues with buffer cap when stream.write throws synchronously (M1)', async () => {
+    mockStream.write.mockImplementation(() => {
+      throw new Error('stream write failed');
+    });
+
+    jest.advanceTimersByTime(1_000);
+    await Promise.resolve();
+    jest.advanceTimersByTime(1_000);
+    await Promise.resolve();
+
+    const senderAny = sender as unknown as { buffer: unknown[]; maxBufferSize: () => number };
+    expect(senderAny.buffer.length).toBeGreaterThan(0);
+    expect(senderAny.buffer.length).toBeLessThanOrEqual(senderAny.maxBufferSize());
+    expect(mockChannelManager.reportError).toHaveBeenCalled();
+  });
+
+  it('always ends stream and does not re-queue after partial writes (L1/L2, Java discard)', async () => {
+    mockStream.write
+      .mockImplementationOnce(() => undefined)
+      .mockImplementationOnce(() => {
+        throw new Error('partial write');
+      });
+
+    jest.advanceTimersByTime(1_000);
+    await Promise.resolve();
+    jest.advanceTimersByTime(1_000);
+    await Promise.resolve();
+
+    expect(mockStream.end).toHaveBeenCalled();
+    const senderAny = sender as unknown as { buffer: unknown[]; maxBufferSize: () => number };
+    expect(senderAny.buffer.length).toBeLessThanOrEqual(senderAny.maxBufferSize());
+    expect(senderAny.buffer.length).toBeLessThanOrEqual(2);
+  });
+
+  it('discards batch when grpc callback fails after stream delivery (Java JVM parity, L2)', async () => {
+    jest.advanceTimersByTime(1_000);
+    await Promise.resolve();
+    jest.advanceTimersByTime(1_000);
+    await Promise.resolve();
+    expect(pendingCollectCallback).toBeDefined();
+
+    const bufferBeforeCallback = (sender as unknown as { buffer: unknown[] }).buffer.length;
+    pendingCollectCallback?.(new Error('UNAVAILABLE'));
+    await Promise.resolve();
+
+    const senderAny = sender as unknown as { buffer: unknown[]; maxBufferSize: () => number };
+    expect(senderAny.buffer.length).toBeLessThanOrEqual(senderAny.maxBufferSize());
+    expect(senderAny.buffer.length).toBeLessThanOrEqual(bufferBeforeCallback + 1);
+  });
+
+  it('enforces buffer cap when failed report re-queues snapshots (B1)', () => {
+    const senderAny = sender as unknown as {
+      buffer: unknown[];
+      requeueSnapshots: (snapshots: unknown[]) => void;
+      maxBufferSize: () => number;
+    };
+    const maxSize = senderAny.maxBufferSize();
+    const failedBatch = Array.from({ length: maxSize }, (_, index) => ({ failed: index }));
+    senderAny.buffer.push(...Array.from({ length: 100 }, (_, index) => ({ live: index })));
+
+    senderAny.requeueSnapshots(failedBatch);
+
+    expect(senderAny.buffer.length).toBe(maxSize);
+  });
+
+  it('disables meter reporting when OAP returns UNIMPLEMENTED (Java MeterSender parity)', async () => {
+    jest.advanceTimersByTime(1_000);
+    await Promise.resolve();
+    jest.advanceTimersByTime(1_000);
+    await Promise.resolve();
+    expect(pendingCollectCallback).toBeDefined();
+
+    const err = Object.assign(new Error('Meter API unimplemented'), { code: grpc.status.UNIMPLEMENTED });
+    pendingCollectCallback?.(err);
+    await Promise.resolve();
+
+    expect(mockChannelManager.reportError).not.toHaveBeenCalled();
+    expect((sender as unknown as { closed: boolean }).closed).toBe(true);
+  });
+
+  describe('shutdown late callback safety (H2 / E6 edge case)', () => {
+    it('does not re-queue buffer when collect callback fires after shutdown', async () => {
+      jest.advanceTimersByTime(1_000);
+      await Promise.resolve();
+      jest.advanceTimersByTime(1_000);
+      await Promise.resolve();
+      expect(pendingCollectCallback).toBeDefined();
+
+      const bufferBefore = (sender as unknown as { buffer: unknown[] }).buffer.length;
+      sender.shutdown();
+      expect((sender as unknown as { buffer: unknown[] }).buffer.length).toBe(0);
+
+      expect(() => pendingCollectCallback?.(new Error('UNAVAILABLE'))).not.toThrow();
+      expect(mockChannelManager.reportError).not.toHaveBeenCalled();
+      expect((sender as unknown as { buffer: unknown[] }).buffer.length).toBe(0);
+      expect(bufferBefore).toBeGreaterThanOrEqual(0);
+    });
+  });
+});

--- a/tests/remote/PrivateKeyUtil.test.ts
+++ b/tests/remote/PrivateKeyUtil.test.ts
@@ -1,0 +1,69 @@
+/*!
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+/* eslint-env jest */
+
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { loadDecryptionKey, loadDecryptionKeyAsync } from '../../src/agent/core/util/PrivateKeyUtil';
+
+function removeDir(dir: string): void {
+  for (const entry of fs.readdirSync(dir)) {
+    fs.unlinkSync(path.join(dir, entry));
+  }
+  fs.rmdirSync(dir);
+}
+
+describe('PrivateKeyUtil (Java PrivateKeyUtil parity)', () => {
+  it('returns PKCS#8 PEM bytes unchanged', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'sw-pkcs8-'));
+    const keyPath = path.join(dir, 'client.pem');
+    const pem = '-----BEGIN PRIVATE KEY-----\nABC\n-----END PRIVATE KEY-----\n';
+    fs.writeFileSync(keyPath, pem);
+    expect(loadDecryptionKey(keyPath).toString('utf8')).toBe(pem);
+    removeDir(dir);
+  });
+
+  it('loadDecryptionKeyAsync reads PKCS#8 PEM (L5)', async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'sw-pkcs8-async-'));
+    const keyPath = path.join(dir, 'client.pem');
+    const pem = '-----BEGIN PRIVATE KEY-----\nABC\n-----END PRIVATE KEY-----\n';
+    fs.writeFileSync(keyPath, pem);
+    await expect(loadDecryptionKeyAsync(keyPath)).resolves.toEqual(Buffer.from(pem, 'utf8'));
+    removeDir(dir);
+  });
+
+  it('converts PKCS#1 RSA PEM to PKCS#8 PEM', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'sw-pkcs1-'));
+    const keyPath = path.join(dir, 'client-rsa.pem');
+    const pkcs1Inner = Buffer.alloc(32, 0xab);
+    const pkcs1Pem = `-----BEGIN RSA PRIVATE KEY-----\n${pkcs1Inner.toString(
+      'base64',
+    )}\n-----END RSA PRIVATE KEY-----\n`;
+    fs.writeFileSync(keyPath, pkcs1Pem);
+
+    const converted = loadDecryptionKey(keyPath).toString('utf8');
+    expect(converted).toContain('-----BEGIN PRIVATE KEY-----');
+    expect(converted).toContain('-----END PRIVATE KEY-----');
+    expect(converted).not.toContain('RSA PRIVATE KEY');
+
+    removeDir(dir);
+  });
+});

--- a/tests/remote/ServiceManagementClient.test.ts
+++ b/tests/remote/ServiceManagementClient.test.ts
@@ -1,0 +1,164 @@
+/*!
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+/* eslint-env jest */
+
+import { GRPCChannelStatus } from '../../src/agent/core/remote/GRPCChannelStatus';
+
+const mockReportInstanceProperties = jest.fn((_req, _meta, opts, cb) => cb(null));
+const mockKeepAlive = jest.fn((_req, _meta, opts, cb) => cb(null));
+const mockGrpcUpstreamDeadlineMs = jest.fn(() => 9_876_543_210);
+let pendingReportCallback: ((error: Error | null) => void) | undefined;
+let pendingKeepAliveCallback: ((error: Error | null) => void) | undefined;
+
+const mockChannelManager = {
+  addChannelListener: jest.fn(),
+  resolveAddress: jest.fn(() => '127.0.0.1:11800'),
+  getClientOptions: jest.fn(() => ({ channelOverride: {} as never })),
+  reportError: jest.fn(),
+};
+
+jest.mock('../../src/config/AgentConfig', () => ({
+  __esModule: true,
+  default: {
+    serviceName: 'test-service',
+    serviceInstance: 'test-instance',
+    collectorHeartbeatPeriod: 20,
+  },
+}));
+
+jest.mock('../../src/proto/management/Management_grpc_pb', () => ({
+  ManagementServiceClient: jest.fn().mockImplementation(() => ({
+    reportInstanceProperties: jest.fn((_req, _meta, opts, cb) => {
+      pendingReportCallback = cb;
+      mockReportInstanceProperties(_req, _meta, opts, cb);
+    }),
+    keepAlive: jest.fn((_req, _meta, opts, cb) => {
+      pendingKeepAliveCallback = cb;
+      mockKeepAlive(_req, _meta, opts, cb);
+    }),
+  })),
+}));
+
+jest.mock('../../src/agent/core/remote/GrpcUpstreamOptions', () => ({
+  grpcUpstreamDeadlineMs: () => mockGrpcUpstreamDeadlineMs(),
+}));
+
+jest.mock('../../src/agent/core/boot/ServiceManager', () => ({
+  __esModule: true,
+  default: {
+    INSTANCE: {
+      findService: jest.fn((serviceClass: { name?: string }) => {
+        if (serviceClass?.name === 'CommandService') {
+          return { receiveCommand: jest.fn() };
+        }
+        return mockChannelManager;
+      }),
+    },
+  },
+}));
+
+jest.mock('../../src/logging', () => ({
+  createLogger: () => ({
+    warn: jest.fn(),
+    info: jest.fn(),
+    error: jest.fn(),
+    _isDebugEnabled: false,
+  }),
+  throttled: () => jest.fn(),
+}));
+
+import ServiceManagementClient from '../../src/agent/core/remote/ServiceManagementClient';
+import config from '../../src/config/AgentConfig';
+
+describe('ServiceManagementClient', () => {
+  let client: ServiceManagementClient;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    mockReportInstanceProperties.mockClear();
+    mockKeepAlive.mockClear();
+    mockGrpcUpstreamDeadlineMs.mockClear();
+    mockChannelManager.reportError.mockClear();
+    pendingReportCallback = undefined;
+    pendingKeepAliveCallback = undefined;
+    (config as { collectorHeartbeatPeriod: number }).collectorHeartbeatPeriod = 20;
+    client = new ServiceManagementClient();
+    client.prepare();
+    client.statusChanged(GRPCChannelStatus.CONNECTED);
+    client.boot();
+  });
+
+  afterEach(() => {
+    client.shutdown();
+    jest.useRealTimers();
+  });
+
+  describe('upstream gRPC deadline', () => {
+    it('passes grpcUpstreamDeadlineMs() as deadline on heartbeat RPCs', () => {
+      jest.advanceTimersByTime(20_000);
+
+      expect(mockGrpcUpstreamDeadlineMs).toHaveBeenCalled();
+      expect(mockReportInstanceProperties).toHaveBeenCalledTimes(1);
+      expect(mockKeepAlive).not.toHaveBeenCalled();
+
+      const reportOpts = mockReportInstanceProperties.mock.calls[0][2];
+      expect(reportOpts).toEqual({ deadline: 9_876_543_210 });
+
+      mockReportInstanceProperties.mockClear();
+      mockKeepAlive.mockClear();
+      jest.advanceTimersByTime(20_000);
+
+      expect(mockKeepAlive).toHaveBeenCalledTimes(1);
+      expect(mockKeepAlive.mock.calls[0][2]).toEqual({ deadline: 9_876_543_210 });
+    });
+  });
+
+  describe('collector heartbeat period (Java HEARTBEAT_PERIOD)', () => {
+    it('uses collectorHeartbeatPeriod seconds for timer interval', () => {
+      (config as { collectorHeartbeatPeriod: number }).collectorHeartbeatPeriod = 5;
+      client.shutdown();
+      client = new ServiceManagementClient();
+      client.prepare();
+      client.statusChanged(GRPCChannelStatus.CONNECTED);
+      client.boot();
+
+      jest.advanceTimersByTime(4_999);
+      expect(mockReportInstanceProperties).not.toHaveBeenCalled();
+
+      jest.advanceTimersByTime(1);
+      expect(mockReportInstanceProperties).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('shutdown late callback safety (H2)', () => {
+    it('does not call reportError when RPC callback fires after shutdown', () => {
+      mockReportInstanceProperties.mockImplementationOnce((_req, _meta, _opts, cb) => {
+        pendingReportCallback = cb;
+      });
+
+      jest.advanceTimersByTime(20_000);
+      expect(pendingReportCallback).toBeDefined();
+
+      client.shutdown();
+      expect(() => pendingReportCallback?.(new Error('UNAVAILABLE'))).not.toThrow();
+      expect(mockChannelManager.reportError).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/tests/remote/ServiceManager.test.ts
+++ b/tests/remote/ServiceManager.test.ts
@@ -1,0 +1,53 @@
+/*!
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+/* eslint-env jest */
+
+jest.mock('../../src/config/AgentConfig', () => ({
+  __esModule: true,
+  default: { runtimeMetricsReporterActive: false },
+}));
+
+jest.mock('../../src/logging', () => ({
+  createLogger: () => ({ error: jest.fn(), warn: jest.fn(), info: jest.fn(), debug: jest.fn() }),
+  throttled: () => jest.fn(),
+}));
+
+import ServiceManager from '../../src/agent/core/boot/ServiceManager';
+import GRPCChannelManager from '../../src/agent/core/remote/GRPCChannelManager';
+
+describe('ServiceManager boot (Java parity)', () => {
+  afterEach(() => {
+    ServiceManager.INSTANCE.shutdown();
+  });
+
+  it('marks booted even when a service boot throws (Java isBooted=true unconditionally)', () => {
+    const manager = ServiceManager.INSTANCE;
+    const original = GRPCChannelManager.prototype.boot;
+    GRPCChannelManager.prototype.boot = () => {
+      throw new Error('boot exploded');
+    };
+
+    manager.boot();
+    expect(manager.isBooted()).toBe(true);
+    expect(manager.findService(GRPCChannelManager)).toBeDefined();
+
+    GRPCChannelManager.prototype.boot = original;
+  });
+});

--- a/tests/remote/TLSChannelBuilder.test.ts
+++ b/tests/remote/TLSChannelBuilder.test.ts
@@ -1,0 +1,308 @@
+/*!
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+/* eslint-env jest */
+
+import fs from 'fs';
+import { promises as fsPromises } from 'fs';
+import path from 'path';
+import * as grpc from '@grpc/grpc-js';
+import { getAgentPackagePath } from '../../src/agent/core/boot/AgentPackagePath';
+import config from '../../src/config/AgentConfig';
+import TLSChannelBuilder from '../../src/agent/core/remote/TLSChannelBuilder';
+import StandardChannelBuilder from '../../src/agent/core/remote/StandardChannelBuilder';
+import { clearTlsMaterialCacheForTest, preloadTlsMaterials } from '../../src/agent/core/remote/TlsMaterialCache';
+
+describe('TLSChannelBuilder (Java TLSChannelBuilder parity)', () => {
+  const original = {
+    secure: config.secure,
+    forceTls: config.forceTls,
+    sslTrustedCaPath: config.sslTrustedCaPath,
+    sslCertChainPath: config.sslCertChainPath,
+    sslKeyPath: config.sslKeyPath,
+    collectorAddress: config.collectorAddress,
+  };
+  const baseContext = {
+    credentials: grpc.credentials.createInsecure(),
+    options: {},
+  };
+
+  beforeEach(() => {
+    clearTlsMaterialCacheForTest();
+    jest.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    config.secure = original.secure;
+    config.forceTls = original.forceTls;
+    config.sslTrustedCaPath = original.sslTrustedCaPath;
+    config.sslCertChainPath = original.sslCertChainPath;
+    config.sslKeyPath = original.sslKeyPath;
+    config.collectorAddress = original.collectorAddress;
+    clearTlsMaterialCacheForTest();
+    jest.restoreAllMocks();
+  });
+
+  async function mockCaFileAndPreload(caPath: string, ca: Buffer, extra?: Record<string, Buffer>): Promise<void> {
+    const fileContents: Record<string, Buffer> = { [caPath]: ca, ...(extra ?? {}) };
+    jest.spyOn(fsPromises, 'lstat').mockImplementation(async (target) => {
+      const filePath = String(target);
+      if (fileContents[filePath]) {
+        return { isFile: () => true, isSymbolicLink: () => false, mode: 0o600, size: 64 } as fs.Stats;
+      }
+      throw new Error('ENOENT');
+    });
+    jest.spyOn(fsPromises, 'realpath').mockImplementation(async (target) => String(target));
+    jest.spyOn(fsPromises, 'open').mockImplementation(async (target) => {
+      const filePath = String(target);
+      const content = fileContents[filePath];
+      if (!content) {
+        throw new Error(`unexpected open ${filePath}`);
+      }
+      return {
+        readFile: async () => content,
+        close: async () => undefined,
+      } as unknown as fsPromises.FileHandle;
+    });
+    await preloadTlsMaterials();
+  }
+
+  it('throws when mTLS paths are configured but key material is missing', async () => {
+    config.secure = true;
+    config.sslTrustedCaPath = '/ca/ca.crt';
+    config.sslCertChainPath = '/ca/client.crt';
+    config.sslKeyPath = '/ca/client.key';
+    await mockCaFileAndPreload('/ca/ca.crt', Buffer.from('TEST-CA'));
+
+    expect(() => new TLSChannelBuilder().build({ ...baseContext })).toThrow('mTLS material unavailable');
+  });
+
+  it('throws when mTLS paths are configured but key material is missing', async () => {
+    config.secure = true;
+    config.sslTrustedCaPath = '/ca/ca.crt';
+    config.sslCertChainPath = '/ca/client.crt';
+    config.sslKeyPath = '/ca/client.key';
+    await mockCaFileAndPreload('/ca/ca.crt', Buffer.from('TEST-CA'));
+
+    expect(() => new TLSChannelBuilder().build({ ...baseContext })).toThrow('mTLS material unavailable');
+  });
+
+  it('throws when mTLS paths are configured but key material is missing', async () => {
+    config.secure = true;
+    config.sslTrustedCaPath = '/ca/ca.crt';
+    config.sslCertChainPath = '/ca/client.crt';
+    config.sslKeyPath = '/ca/client.key';
+    await mockCaFileAndPreload('/ca/ca.crt', Buffer.from('TEST-CA'));
+
+    expect(() => new TLSChannelBuilder().build({ ...baseContext })).toThrow('mTLS material unavailable');
+  });
+
+  it('uses TLS without CA verification when SW_AGENT_SECURE is true but CA file is missing (Java force_tls parity)', () => {
+    config.secure = true;
+    config.forceTls = false;
+    config.sslTrustedCaPath = '';
+    const sslCredentials = {} as grpc.ChannelCredentials;
+    const createSslSpy = jest.spyOn(grpc.credentials, 'createSsl').mockReturnValue(sslCredentials);
+
+    const result = new TLSChannelBuilder().build({ ...baseContext });
+
+    expect(createSslSpy).toHaveBeenCalledWith();
+    expect(result.credentials).toBe(sslCredentials);
+  });
+
+  it('uses system trust store when SW_AGENT_FORCE_TLS is true but CA file is missing (Java force_tls parity)', () => {
+    config.secure = false;
+    config.forceTls = true;
+    config.sslTrustedCaPath = 'ca/ca.crt';
+    jest.spyOn(fs, 'statSync').mockImplementation(() => {
+      throw new Error('ENOENT');
+    });
+    const sslCredentials = {} as grpc.ChannelCredentials;
+    const createSslSpy = jest.spyOn(grpc.credentials, 'createSsl').mockReturnValue(sslCredentials);
+
+    const result = new TLSChannelBuilder().build({ ...baseContext });
+
+    expect(createSslSpy).toHaveBeenCalledWith();
+    expect(result.credentials).toBe(sslCredentials);
+  });
+
+  it('loads trusted CA from relative ca/ca.crt under agent package (Java default layout)', async () => {
+    config.secure = false;
+    config.forceTls = false;
+    config.sslTrustedCaPath = 'ca/ca.crt';
+    const ca = Buffer.from('TEST-CA');
+    const caPath = path.join(getAgentPackagePath(), 'ca/ca.crt');
+    await mockCaFileAndPreload(caPath, ca);
+    const createSslSpy = jest.spyOn(grpc.credentials, 'createSsl').mockReturnValue({} as grpc.ChannelCredentials);
+
+    new TLSChannelBuilder().build({ ...baseContext });
+
+    expect(createSslSpy).toHaveBeenCalledWith(ca, null, null);
+  });
+
+  it('loads trusted CA from absolute SW_AGENT_SSL_TRUSTED_CA_PATH', async () => {
+    config.secure = false;
+    config.forceTls = false;
+    config.sslTrustedCaPath = '/ca/ca.crt';
+    const ca = Buffer.from('TEST-CA');
+    await mockCaFileAndPreload('/ca/ca.crt', ca);
+    const createSslSpy = jest.spyOn(grpc.credentials, 'createSsl').mockReturnValue({} as grpc.ChannelCredentials);
+
+    new TLSChannelBuilder().build({ ...baseContext });
+
+    expect(createSslSpy).toHaveBeenCalledWith(ca, null, null);
+  });
+
+  it('loads private key via PrivateKeyUtil.loadDecryptionKey for mTLS', async () => {
+    config.secure = false;
+    config.forceTls = false;
+    config.sslTrustedCaPath = '/ca/ca.crt';
+    config.sslCertChainPath = '/ca/client.crt';
+    config.sslKeyPath = '/ca/client.pem';
+    const ca = Buffer.from('CA');
+    const cert = Buffer.from('CERT');
+    const key = Buffer.from('KEY-PEM');
+    await mockCaFileAndPreload('/ca/ca.crt', ca, {
+      '/ca/client.crt': cert,
+      '/ca/client.pem': key,
+    });
+    const sslCredentials = {} as grpc.ChannelCredentials;
+    const createSslSpy = jest.spyOn(grpc.credentials, 'createSsl').mockReturnValue(sslCredentials);
+
+    new TLSChannelBuilder().build({ ...baseContext });
+
+    expect(createSslSpy).toHaveBeenCalledWith(ca, key, cert);
+  });
+
+  it('enables mTLS when cert chain and key files exist under agent package', async () => {
+    config.secure = false;
+    config.forceTls = false;
+    config.sslTrustedCaPath = 'ca/ca.crt';
+    config.sslCertChainPath = 'ca/client.crt';
+    config.sslKeyPath = 'ca/client.key';
+    const ca = Buffer.from('CA');
+    const cert = Buffer.from('CERT');
+    const key = Buffer.from('KEY');
+    const root = getAgentPackagePath();
+    await mockCaFileAndPreload(path.join(root, 'ca/ca.crt'), ca, {
+      [path.join(root, 'ca/client.crt')]: cert,
+      [path.join(root, 'ca/client.key')]: key,
+    });
+    const createSslSpy = jest.spyOn(grpc.credentials, 'createSsl').mockReturnValue({} as grpc.ChannelCredentials);
+
+    new TLSChannelBuilder().build({ ...baseContext });
+
+    expect(createSslSpy).toHaveBeenCalledWith(ca, key, cert);
+  });
+
+  it('keeps insecure credentials when TLS is not enabled and default ca file is absent', () => {
+    config.secure = false;
+    config.forceTls = false;
+    config.sslTrustedCaPath = 'ca/ca.crt';
+    jest.spyOn(fs, 'statSync').mockImplementation(() => {
+      throw new Error('ENOENT');
+    });
+    const createSslSpy = jest.spyOn(grpc.credentials, 'createSsl');
+    const insecure = grpc.credentials.createInsecure();
+
+    const result = new TLSChannelBuilder().build({ credentials: insecure, options: {} });
+
+    expect(createSslSpy).not.toHaveBeenCalled();
+    expect(result.credentials).toBe(insecure);
+  });
+
+  it('sets grpc.ssl_target_name_override when connecting to resolved IP under TLS', async () => {
+    config.secure = true;
+    config.sslTrustedCaPath = '/ca/ca.crt';
+    config.collectorAddress = 'oap:11800';
+    await mockCaFileAndPreload('/ca/ca.crt', Buffer.from('TEST-CA'));
+    jest.spyOn(grpc.credentials, 'createSsl').mockReturnValue({} as grpc.ChannelCredentials);
+
+    const result = new TLSChannelBuilder().build({
+      ...baseContext,
+      connectHost: '10.0.0.1',
+    });
+
+    expect(result.options['grpc.ssl_target_name_override']).toBe('oap');
+  });
+
+  it('does not set grpc.ssl_target_name_override when connect host is hostname', async () => {
+    config.secure = true;
+    config.sslTrustedCaPath = '/ca/ca.crt';
+    config.collectorAddress = 'oap:11800';
+    await mockCaFileAndPreload('/ca/ca.crt', Buffer.from('TEST-CA'));
+    jest.spyOn(grpc.credentials, 'createSsl').mockReturnValue({} as grpc.ChannelCredentials);
+
+    const result = new TLSChannelBuilder().build({
+      ...baseContext,
+      connectHost: 'oap',
+    });
+
+    expect(result.options['grpc.ssl_target_name_override']).toBeUndefined();
+  });
+
+  it('context.tlsServerName takes precedence over deriveTlsServerNameForConnectHost', async () => {
+    config.secure = true;
+    config.sslTrustedCaPath = '/ca/ca.crt';
+    config.collectorAddress = 'first:11800,second:11800';
+    await mockCaFileAndPreload('/ca/ca.crt', Buffer.from('TEST-CA'));
+    jest.spyOn(grpc.credentials, 'createSsl').mockReturnValue({} as grpc.ChannelCredentials);
+
+    const result = new TLSChannelBuilder().build({
+      ...baseContext,
+      connectHost: '10.0.0.1',
+      tlsServerName: 'second',
+    });
+
+    expect(result.options['grpc.ssl_target_name_override']).toBe('second');
+  });
+
+  it('uses TLS without CA verification when FORCE_TLS is set and preload found no CA file (Java parity)', async () => {
+    config.secure = false;
+    config.forceTls = true;
+    config.sslTrustedCaPath = '/ca/ca.crt';
+    jest.spyOn(fsPromises, 'stat').mockRejectedValue(new Error('ENOENT'));
+    jest.spyOn(fsPromises, 'readFile').mockRejectedValue(new Error('ENOENT'));
+    await preloadTlsMaterials();
+    const sslCredentials = {} as grpc.ChannelCredentials;
+    const createSslSpy = jest.spyOn(grpc.credentials, 'createSsl').mockReturnValue(sslCredentials);
+
+    const result = new TLSChannelBuilder().build({ ...baseContext });
+
+    expect(createSslSpy).toHaveBeenCalledWith();
+    expect(result.credentials).toBe(sslCredentials);
+  });
+
+  it('StandardChannelBuilder preserves connectHost for TLS SNI override chain', async () => {
+    config.secure = true;
+    config.sslTrustedCaPath = '/ca/ca.crt';
+    config.collectorAddress = 'oap:11800';
+    await mockCaFileAndPreload('/ca/ca.crt', Buffer.from('TEST-CA'));
+    jest.spyOn(grpc.credentials, 'createSsl').mockReturnValue({} as grpc.ChannelCredentials);
+
+    const result = new TLSChannelBuilder().build(
+      new StandardChannelBuilder().build({
+        ...baseContext,
+        connectHost: '10.0.0.1',
+      }),
+    );
+
+    expect(result.options['grpc.ssl_target_name_override']).toBe('oap');
+  });
+});

--- a/tests/remote/TlsMaterialCache.test.ts
+++ b/tests/remote/TlsMaterialCache.test.ts
@@ -1,0 +1,184 @@
+/*!
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+/* eslint-env jest */
+
+import fs from 'fs';
+import path from 'path';
+import config from '../../src/config/AgentConfig';
+import { getAgentPackagePath } from '../../src/agent/core/boot/AgentPackagePath';
+import {
+  clearTlsMaterialCacheForTest,
+  clearTlsMaterialCacheOnShutdown,
+  getTlsMaterials,
+  preloadTlsMaterials,
+} from '../../src/agent/core/remote/TlsMaterialCache';
+
+describe('TlsMaterialCache', () => {
+  const original = {
+    sslTrustedCaPath: config.sslTrustedCaPath,
+    sslCertChainPath: config.sslCertChainPath,
+    sslKeyPath: config.sslKeyPath,
+  };
+
+  function mockRegularTlsFileIO(readFileImpl?: jest.Mock): void {
+    jest
+      .spyOn(fs.promises, 'lstat')
+      .mockResolvedValue({ isFile: () => true, isSymbolicLink: () => false, mode: 0o600, size: 64 } as fs.Stats);
+    jest.spyOn(fs.promises, 'realpath').mockImplementation(async (target) => String(target));
+    const fileHandle = {
+      readFile: readFileImpl ?? jest.fn().mockResolvedValue(Buffer.from('CA')),
+      close: jest.fn().mockResolvedValue(undefined),
+    };
+    jest.spyOn(fs.promises, 'open').mockResolvedValue(fileHandle as unknown as fs.promises.FileHandle);
+  }
+
+  beforeEach(() => {
+    clearTlsMaterialCacheForTest();
+    jest.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    config.sslTrustedCaPath = original.sslTrustedCaPath;
+    config.sslCertChainPath = original.sslCertChainPath;
+    config.sslKeyPath = original.sslKeyPath;
+    clearTlsMaterialCacheForTest();
+  });
+
+  it('reloads CA bytes on each preload call (Java channel rebuild parity)', async () => {
+    config.sslTrustedCaPath = 'ca/ca.crt';
+    config.sslCertChainPath = '';
+    config.sslKeyPath = '';
+    const caPath = path.join(getAgentPackagePath(), 'ca/ca.crt');
+    const first = Buffer.from('CA-1');
+    const second = Buffer.from('CA-2');
+    const fileHandle = { readFile: jest.fn(), close: jest.fn().mockResolvedValue(undefined) };
+    mockRegularTlsFileIO(fileHandle.readFile);
+    fileHandle.readFile.mockResolvedValueOnce(first).mockResolvedValueOnce(second);
+
+    const firstLoad = await preloadTlsMaterials();
+    const secondLoad = await preloadTlsMaterials();
+
+    expect(firstLoad.rootCerts).toEqual(first);
+    expect(secondLoad.rootCerts).toEqual(second);
+    expect(String(caPath)).toBeTruthy();
+  });
+
+  it('clearTlsMaterialCacheOnShutdown clears cached snapshot (Java shutdown parity)', async () => {
+    config.sslTrustedCaPath = 'ca/ca.crt';
+    config.sslCertChainPath = '';
+    config.sslKeyPath = '';
+    mockRegularTlsFileIO();
+
+    await preloadTlsMaterials();
+    expect(getTlsMaterials()).not.toBeNull();
+
+    clearTlsMaterialCacheOnShutdown();
+    expect(getTlsMaterials()).toBeNull();
+  });
+
+  it('rejects symbolic link TLS paths (B-1)', async () => {
+    config.sslTrustedCaPath = 'ca/ca.crt';
+    config.sslCertChainPath = '';
+    config.sslKeyPath = '';
+    jest.spyOn(fs.promises, 'lstat').mockResolvedValue({ isFile: () => false, isSymbolicLink: () => true } as fs.Stats);
+    const openSpy = jest.spyOn(fs.promises, 'open');
+
+    const materials = await preloadTlsMaterials();
+
+    expect(materials.rootCerts).toBeNull();
+    expect(openSpy).not.toHaveBeenCalled();
+  });
+
+  it('rejects TLS file when realpath resolves outside agent package (hardlink, H-1)', async () => {
+    config.sslTrustedCaPath = 'ca/ca.crt';
+    config.sslCertChainPath = '';
+    config.sslKeyPath = '';
+    jest
+      .spyOn(fs.promises, 'lstat')
+      .mockResolvedValue({ isFile: () => true, isSymbolicLink: () => false, mode: 0o600, size: 64 } as fs.Stats);
+    jest.spyOn(fs.promises, 'realpath').mockResolvedValue('/etc/passwd');
+    const openSpy = jest.spyOn(fs.promises, 'open');
+
+    const materials = await preloadTlsMaterials();
+
+    expect(materials.rootCerts).toBeNull();
+    expect(openSpy).not.toHaveBeenCalled();
+  });
+
+  it('rejects TLS file when realpath resolves outside agent package (hardlink, H-1)', async () => {
+    config.sslTrustedCaPath = 'ca/ca.crt';
+    config.sslCertChainPath = '';
+    config.sslKeyPath = '';
+    jest
+      .spyOn(fs.promises, 'lstat')
+      .mockResolvedValue({ isFile: () => true, isSymbolicLink: () => false, mode: 0o600, size: 64 } as fs.Stats);
+    jest.spyOn(fs.promises, 'realpath').mockResolvedValue('/etc/passwd');
+    const openSpy = jest.spyOn(fs.promises, 'open');
+
+    const materials = await preloadTlsMaterials();
+
+    expect(materials.rootCerts).toBeNull();
+    expect(openSpy).not.toHaveBeenCalled();
+  });
+
+  it('rejects TLS file when realpath resolves outside agent package (hardlink, H-1)', async () => {
+    config.sslTrustedCaPath = 'ca/ca.crt';
+    config.sslCertChainPath = '';
+    config.sslKeyPath = '';
+    jest
+      .spyOn(fs.promises, 'lstat')
+      .mockResolvedValue({ isFile: () => true, isSymbolicLink: () => false, mode: 0o600, size: 64 } as fs.Stats);
+    jest.spyOn(fs.promises, 'realpath').mockResolvedValue('/etc/passwd');
+    const openSpy = jest.spyOn(fs.promises, 'open');
+
+    const materials = await preloadTlsMaterials();
+
+    expect(materials.rootCerts).toBeNull();
+    expect(openSpy).not.toHaveBeenCalled();
+  });
+
+  it('rejects TLS file exceeding max size (SEC-11)', async () => {
+    config.sslTrustedCaPath = 'ca/ca.crt';
+    config.sslCertChainPath = '';
+    config.sslKeyPath = '';
+    jest.spyOn(fs.promises, 'lstat').mockResolvedValue({
+      isFile: () => true,
+      isSymbolicLink: () => false,
+      mode: 0o600,
+      size: 512 * 1024,
+    } as fs.Stats);
+    const openSpy = jest.spyOn(fs.promises, 'open');
+
+    const materials = await preloadTlsMaterials();
+
+    expect(materials.rootCerts).toBeNull();
+    expect(openSpy).not.toHaveBeenCalled();
+  });
+
+  it('returns null CA material for path traversal without throwing', async () => {
+    config.sslTrustedCaPath = '../../../etc/passwd';
+    config.sslCertChainPath = '';
+    config.sslKeyPath = '';
+
+    const materials = await preloadTlsMaterials();
+
+    expect(materials.rootCerts).toBeNull();
+  });
+});

--- a/tests/remote/TraceSegmentServiceClient.test.ts
+++ b/tests/remote/TraceSegmentServiceClient.test.ts
@@ -1,0 +1,193 @@
+/*!
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+/* eslint-env jest */
+
+import { GRPCChannelStatus } from '../../src/agent/core/remote/GRPCChannelStatus';
+
+const mockCollect = jest.fn();
+const mockGrpcUpstreamDeadlineMs = jest.fn(() => 1_234_567_890);
+let pendingCollectCallback: ((error: Error | null) => void) | undefined;
+
+const mockChannelManager = {
+  addChannelListener: jest.fn(),
+  resolveAddress: jest.fn(() => '127.0.0.1:11800'),
+  getClientOptions: jest.fn(() => ({ channelOverride: {} as never })),
+  reportError: jest.fn(),
+};
+
+const mockStream = {
+  write: jest.fn(),
+  end: jest.fn(),
+};
+
+jest.mock('../../src/config/AgentConfig', () => ({
+  __esModule: true,
+  default: {
+    maxBufferSize: 300,
+    collectorAddress: '127.0.0.1:11800',
+  },
+}));
+
+jest.mock('../../src/proto/language-agent/Tracing_grpc_pb', () => ({
+  TraceSegmentReportServiceClient: jest.fn().mockImplementation(() => ({
+    collect: jest.fn((_meta, opts, cb) => {
+      pendingCollectCallback = cb;
+      return mockCollect(_meta, opts, cb);
+    }),
+  })),
+}));
+
+jest.mock('../../src/agent/core/remote/GrpcUpstreamOptions', () => ({
+  grpcUpstreamDeadlineMs: () => mockGrpcUpstreamDeadlineMs(),
+}));
+
+jest.mock('../../src/agent/core/boot/ServiceManager', () => ({
+  __esModule: true,
+  default: {
+    INSTANCE: {
+      findService: jest.fn(() => mockChannelManager),
+    },
+  },
+}));
+
+jest.mock('../../src/logging', () => ({
+  createLogger: () => ({
+    warn: jest.fn(),
+    info: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+    _isDebugEnabled: false,
+  }),
+  throttled: () => jest.fn(),
+}));
+
+jest.mock('../../src/lib/EventEmitter', () => ({
+  emitter: {
+    on: jest.fn(),
+    off: jest.fn(),
+    emit: jest.fn(),
+  },
+}));
+
+import { emitter } from '../../src/lib/EventEmitter';
+import TraceSegmentServiceClient from '../../src/agent/core/remote/TraceSegmentServiceClient';
+import { TraceSegmentReportServiceClient } from '../../src/proto/language-agent/Tracing_grpc_pb';
+
+describe('TraceSegmentServiceClient', () => {
+  let client: TraceSegmentServiceClient;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    mockCollect.mockClear();
+    mockGrpcUpstreamDeadlineMs.mockClear();
+    (TraceSegmentReportServiceClient as jest.Mock).mockClear();
+    mockChannelManager.reportError.mockClear();
+    mockStream.write.mockReset();
+    mockStream.write.mockImplementation(() => undefined);
+    mockStream.end.mockReset();
+    mockStream.end.mockImplementation(() => undefined);
+    pendingCollectCallback = undefined;
+    mockCollect.mockImplementation((_meta, _opts, cb) => {
+      pendingCollectCallback = cb;
+      return mockStream;
+    });
+    client = new TraceSegmentServiceClient();
+    client.prepare();
+    client.statusChanged(GRPCChannelStatus.CONNECTED);
+    client.boot();
+  });
+
+  afterEach(() => {
+    client.shutdown();
+    jest.useRealTimers();
+  });
+
+  it('does not ref report timer when buffer has segments (allows process exit)', () => {
+    const segmentListener = (emitter.on as jest.Mock).mock.calls.find((call) => call[0] === 'segment-finished')?.[1];
+    expect(segmentListener).toBeDefined();
+
+    const timeout = (client as unknown as { timeout: NodeJS.Timeout }).timeout;
+    expect(timeout).toBeDefined();
+    const refSpy = jest.spyOn(timeout, 'ref');
+
+    segmentListener?.({ transform: () => ({}) });
+
+    expect(refSpy).not.toHaveBeenCalled();
+    refSpy.mockRestore();
+  });
+
+  it('clears reporter stub on DISCONNECT', () => {
+    client.statusChanged(GRPCChannelStatus.DISCONNECT);
+    expect(TraceSegmentReportServiceClient).toHaveBeenCalledTimes(1);
+  });
+
+  it('passes grpcUpstreamDeadlineMs() as deadline on collect', async () => {
+    (client as unknown as { buffer: unknown[] }).buffer.push({ transform: () => ({}) });
+
+    jest.advanceTimersByTime(1_000);
+    await Promise.resolve();
+
+    expect(mockGrpcUpstreamDeadlineMs).toHaveBeenCalled();
+    expect(mockCollect).toHaveBeenCalledWith(expect.anything(), { deadline: 1_234_567_890 }, expect.any(Function));
+  });
+
+  it('re-queues with buffer cap when stream.write throws synchronously (B2)', async () => {
+    mockStream.write.mockImplementation(() => {
+      throw new Error('stream write failed');
+    });
+
+    (client as unknown as { buffer: unknown[] }).buffer.push({ transform: () => ({}) });
+
+    jest.advanceTimersByTime(1_000);
+    await Promise.resolve();
+
+    const clientAny = client as unknown as { buffer: unknown[] };
+    expect(clientAny.buffer.length).toBe(1);
+    expect(mockChannelManager.reportError).toHaveBeenCalled();
+  });
+
+  it('discards batch when grpc callback fails after stream delivery (Java parity, B2)', async () => {
+    (client as unknown as { buffer: unknown[] }).buffer.push({ transform: () => ({}) });
+
+    jest.advanceTimersByTime(1_000);
+    await Promise.resolve();
+    expect(pendingCollectCallback).toBeDefined();
+
+    pendingCollectCallback?.(new Error('UNAVAILABLE'));
+    await Promise.resolve();
+
+    const clientAny = client as unknown as { buffer: unknown[] };
+    expect(clientAny.buffer.length).toBe(0);
+  });
+
+  describe('shutdown late callback safety (H2)', () => {
+    it('does not call reportError when collect callback fires after shutdown', async () => {
+      (client as unknown as { buffer: unknown[] }).buffer.push({ transform: () => ({}) });
+
+      jest.advanceTimersByTime(1_000);
+      await Promise.resolve();
+      expect(pendingCollectCallback).toBeDefined();
+
+      client.shutdown();
+      expect(() => pendingCollectCallback?.(new Error('UNAVAILABLE'))).not.toThrow();
+      expect(mockChannelManager.reportError).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/tests/runtime/RuntimeMetricsCollector.test.ts
+++ b/tests/runtime/RuntimeMetricsCollector.test.ts
@@ -20,6 +20,22 @@
 /* eslint-env jest */
 
 import RuntimeMetricsCollector from '../../src/agent/core/meter/RuntimeMetricsCollector';
+import { RuntimeSnapshot } from '../../src/agent/core/meter/RuntimeSampler';
+
+const EXPECTED_METER_NAMES = [
+  'instance_nodejs_process_cpu',
+  'instance_nodejs_heap_used',
+  'instance_nodejs_heap_total',
+  'instance_nodejs_heap_limit',
+  'instance_nodejs_rss',
+  'instance_nodejs_external_memory',
+  'instance_nodejs_array_buffers',
+  'instance_nodejs_uptime',
+  'instance_nodejs_peak_malloced_memory',
+  'instance_nodejs_detached_contexts',
+  'instance_nodejs_old_space_used',
+  'instance_nodejs_new_space_used',
+];
 
 describe('RuntimeMetricsCollector', () => {
   let collector: RuntimeMetricsCollector;
@@ -37,21 +53,57 @@ describe('RuntimeMetricsCollector', () => {
     const meters = collector.toMeterData(snapshot);
     const names = meters.map((meter) => meter.getSinglevalue()?.getName());
 
-    expect(names).toEqual(
-      expect.arrayContaining([
-        'instance_nodejs_process_cpu',
-        'instance_nodejs_heap_used',
-        'instance_nodejs_heap_total',
-        'instance_nodejs_heap_limit',
-        'instance_nodejs_rss',
-        'instance_nodejs_external_memory',
-      ]),
-    );
-
-    expect(names).toHaveLength(6);
+    expect(names).toEqual(EXPECTED_METER_NAMES);
 
     for (const meter of meters) {
       expect(meter.getSinglevalue()?.getValue()).toBeGreaterThanOrEqual(0);
     }
+
+    expect(snapshot.uptime).toBeGreaterThanOrEqual(0);
+    expect(snapshot.oldSpaceUsed).toBeGreaterThanOrEqual(0);
+    expect(snapshot.newSpaceUsed).toBeGreaterThanOrEqual(0);
+  });
+
+  it('maps extended runtime snapshot values into meter single values', () => {
+    const snapshot: RuntimeSnapshot = {
+      collectedAt: 1_700_000_000_000,
+      heapUsed: 100,
+      heapTotal: 200,
+      heapSizeLimit: 300,
+      rss: 400,
+      external: 50,
+      cpuUserPercent: 1.2,
+      cpuSystemPercent: 0.8,
+      arrayBuffers: 16,
+      uptime: 42.5,
+      peakMallocedMemory: 2048,
+      detachedContexts: 3,
+      oldSpaceUsed: 88,
+      newSpaceUsed: 12,
+    };
+
+    const meters = collector.toMeterData(snapshot);
+    const values: Record<string, number | undefined> = {};
+    for (const meter of meters) {
+      const name = meter.getSinglevalue()?.getName();
+      if (name) {
+        values[name] = meter.getSinglevalue()?.getValue();
+      }
+    }
+
+    expect(values).toEqual({
+      instance_nodejs_process_cpu: 2,
+      instance_nodejs_heap_used: 100,
+      instance_nodejs_heap_total: 200,
+      instance_nodejs_heap_limit: 300,
+      instance_nodejs_rss: 400,
+      instance_nodejs_external_memory: 50,
+      instance_nodejs_array_buffers: 16,
+      instance_nodejs_uptime: 42.5,
+      instance_nodejs_peak_malloced_memory: 2048,
+      instance_nodejs_detached_contexts: 3,
+      instance_nodejs_old_space_used: 88,
+      instance_nodejs_new_space_used: 12,
+    });
   });
 });

--- a/tests/runtime/RuntimeSampler.test.ts
+++ b/tests/runtime/RuntimeSampler.test.ts
@@ -1,0 +1,87 @@
+/*!
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+/* eslint-env jest */
+
+import v8 from 'v8';
+import RuntimeSampler from '../../src/agent/core/meter/RuntimeSampler';
+
+describe('RuntimeSampler', () => {
+  let sampler: RuntimeSampler;
+
+  beforeEach(() => {
+    sampler = new RuntimeSampler();
+  });
+
+  afterEach(() => {
+    sampler.destroy();
+  });
+
+  it('records collectedAt at sample time', () => {
+    jest.spyOn(Date, 'now').mockReturnValueOnce(1_700_000_000_000);
+    expect(sampler.sample().collectedAt).toBe(1_700_000_000_000);
+  });
+
+  it('samples array buffers, uptime, heap stats, and heap spaces', () => {
+    const memoryUsageSpy = jest.spyOn(process, 'memoryUsage').mockReturnValue({
+      rss: 1,
+      heapTotal: 2,
+      heapUsed: 3,
+      external: 4,
+      arrayBuffers: 5,
+    });
+    const uptimeSpy = jest.spyOn(process, 'uptime').mockReturnValue(99);
+    const heapStatsSpy = jest.spyOn(v8, 'getHeapStatistics').mockReturnValue({
+      heap_size_limit: 1000,
+      peak_malloced_memory: 2000,
+      number_of_detached_contexts: 7,
+    } as ReturnType<typeof v8.getHeapStatistics>);
+    const heapSpaceSpy = jest
+      .spyOn(v8, 'getHeapSpaceStatistics')
+      .mockReturnValue([
+        { space_name: 'old_space', space_used_size: 80 } as v8.HeapSpaceInfo,
+        { space_name: 'new_space', space_used_size: 20 } as v8.HeapSpaceInfo,
+      ]);
+
+    const snapshot = sampler.sample();
+
+    expect(snapshot.arrayBuffers).toBe(5);
+    expect(snapshot.uptime).toBe(99);
+    expect(snapshot.peakMallocedMemory).toBe(2000);
+    expect(snapshot.detachedContexts).toBe(7);
+    expect(snapshot.oldSpaceUsed).toBe(80);
+    expect(snapshot.newSpaceUsed).toBe(20);
+
+    memoryUsageSpy.mockRestore();
+    uptimeSpy.mockRestore();
+    heapStatsSpy.mockRestore();
+    heapSpaceSpy.mockRestore();
+  });
+
+  it('defaults missing heap spaces to zero', () => {
+    jest.spyOn(v8, 'getHeapSpaceStatistics').mockReturnValue([]);
+
+    const snapshot = sampler.sample();
+
+    expect(snapshot.oldSpaceUsed).toBe(0);
+    expect(snapshot.newSpaceUsed).toBe(0);
+
+    jest.restoreAllMocks();
+  });
+});


### PR DESCRIPTION
### Summary

This PR extends the Node.js agent remote layer to align with the **Java `agent.core` gRPC architecture**, and expands runtime metrics from 6 to **12** `instance_nodejs_*` meters.

1. **gRPC v2** — `GRPCChannelManager` multi-backend failover, TLS/mTLS, per-hostname SNI, DNS expand (A/AAAA), optional periodic DNS re-resolve, IPv6 `formatHostPort`, `CommandService` ingestion.
2. **Runtime metrics** — six additional meters (`array_buffers`, `uptime`, `peak_malloced_memory`, `detached_contexts`, `old_space_used`, `new_space_used`); canonical env `SW_AGENT_RUNTIME_METRICS_*` with legacy aliases retained.

**Not in this PR:** OAP MAL rules / dashboards (separate PR required), release version bump, Profile/Log/Event clients, full Command executor registration.

### Motivation

- **Cross-language parity:** Java agent already uses `GRPCChannelManager`, TLS, DNS expansion, and periodic re-resolve; Node previously lacked equivalent failover and TLS/SNI behavior (notably Kubernetes Headless Service → Pod IP with cert hostname mismatch).
- **Maintainability:** v1 refactor introduced `agent.core` layout; v2 completes remote connectivity features on that foundation.

### OAP companion (required for 12-meter dashboards)

Meter **reporting** is in this PR. **OAP consumption** (MAL analyzer + dashboard docs + e2e-v2 TLS/DNS/auth cases) is a **separate PR** to `apache/skywalking`:

| Item | Location |
|------|----------|
| 12 MAL rules | `meter-analyzer-config/nodejs-runtime.yaml` |
| Dashboard doc | `docs/en/setup/backend/dashboards-nodejs-runtime.md` |
| Node.js e2e (ssl / mtls / ssl-dns / auth) | `test/e2e-v2/cases/nodejs/*` |
| Agent pin | `test/e2e-v2/script/env` → `SW_AGENT_NODEJS_COMMIT=7c7eba5` |

Companion OAP PR: [songzhendong/skywalking #6](https://github.com/songzhendong/skywalking/pull/6).

### Intentional differences from Java (please review)

| Area | Java | This PR | Tag |
|------|------|---------|-----|
| Auth failure (`UNAUTHENTICATED` / `PERMISSION_DENIED`) | Treated as network error → reconnect | Log warn, **no reconnect** | Stricter ops behavior |
| mTLS paths set but PEM missing | Warn, continue one-way TLS | **throw** at channel build | Stricter |
| Meter burst on reconnect | No per-tick snapshot cap | `SW_AGENT_RUNTIME_METRICS_MAX_SNAPSHOTS_PER_REPORT` default **1** | Tunable guard |
| Exported `config` to apps | `Config.Agent.AUTHENTICATION` readable | `publicAgentConfig` omits `authorization` | Node-only hardening |

Operational constraints (DNS lookup blocking, runtime sampling on main thread, etc.): [`docs/nodejs-grpc-constraints.md`](docs/nodejs-grpc-constraints.md).

### Key env vars (new / renamed)

| Variable | Purpose |
|----------|---------|
| `SW_AGENT_IS_RESOLVE_DNS_PERIODICALLY` | Periodic DNS re-resolve (Java `collector.is_resolve_dns_periodically`) |
| `SW_AGENT_GRPC_CHANNEL_CHECK_INTERVAL` | Channel health check interval (seconds) |
| `SW_AGENT_FORCE_RECONNECTION_PERIOD` | Force reconnect period multiplier |
| `SW_AGENT_FORCE_TLS` / `SW_AGENT_SSL_*` | TLS/mTLS material paths |
| `SW_AGENT_COLLECTOR_GRPC_UPSTREAM_TIMEOUT` | gRPC call deadline (seconds) |
| `SW_AGENT_RUNTIME_METRICS_*` | Runtime meter pipeline (replaces `SW_AGENT_NODEJS_RUNTIME_METRICS_*` as canonical) |

Legacy `SW_AGENT_NODEJS_RUNTIME_METRICS_*`, `SW_AGENT_NVM_*` aliases still accepted with deprecation warnings.

### Test plan

**Agent CI** ([Actions run @ `7c7eba5`](https://github.com/songzhendong/skywalking-nodejs/actions/runs/28783670639)):

- [x] Build (Node 20 / 22 / 24)
- [x] License
- [x] Lint + TestLib
- [x] **TestUnitRemote** (config / core / remote / runtime) × 20/22/24
- [x] **TestRemoteE2E** (`static-failover`, `dns-re-resolve`) × 20/22/24
- [x] **TestPlugins** matrix (express meterSize 12, axios, http, ioredis, mongodb, mysql, …)

**OAP e2e-v2** ([songzhendong/skywalking #6](https://github.com/songzhendong/skywalking/pull/6), pin `7c7eba5`):

- [x] Agent NodeJS Backend / Frontend / Frontend ES / Frontend ES Sharding
- [x] Agent NodeJS SSL / SSL DNS / mTLS / Auth

### Files of note

| Path | Role |
|------|------|
| `src/agent/core/remote/*` | Channel manager, TLS, DNS resolver, clients |
| `src/agent/core/commands/*` | OAP command queue + dispatch framework |
| `src/agent/core/meter/*` | 12 runtime meters |
| `tests/remote-e2e/*` | Docker-compose failover E2E (CI) |
| `tests/remote/*` | Unit tests for remote layer |
| `docs/nodejs-grpc-constraints.md` | Node/grpc-js operational notes |